### PR TITLE
style(alert): add color on icon

### DIFF
--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -19,19 +19,31 @@ interface AlertProps {
 
 const Alert: React.FC<AlertProps> = (props: AlertProps) => {
   const [alertStatus, setAlertStatus] = useState(true);
-  const { message, description, closeable, showIcon, colseText, onClose, icon, type = 'info', size = 'middle' } = props;
+  const {
+    message,
+    description,
+    closeable,
+    showIcon = false,
+    colseText,
+    onClose,
+    icon,
+    type = 'info',
+    size = 'middle',
+  } = props;
 
   const getIcon = () => {
-    const { type } = props;
+    const { type, showIcon } = props;
     switch (type) {
       case 'success':
-        return <CheckCircleFilled />;
+        return <CheckCircleFilled color="#00875A" />;
       case 'warning':
-        return <WarningFilled />;
+        return <WarningFilled color="#FF991F" />;
       case 'error':
-        return <CloseCircleFilled />;
+        return <CloseCircleFilled color="#DE350B" />;
+      case 'info':
+        return <InformationFilled color="#0052CC" />;
       default:
-        return <InformationFilled />;
+        return showIcon ? icon || <InformationFilled color="#0052CC" /> : null;
     }
   };
 
@@ -50,7 +62,7 @@ const Alert: React.FC<AlertProps> = (props: AlertProps) => {
         )}
       >
         <div className="gio-alert-icon" style={{ display: showIcon ? 'block' : 'none' }}>
-          {icon || getIcon()}
+          {getIcon()}
         </div>
         <div className="gio-alert-content">
           <div className="gio-alert-content-title" style={{ display: message ? 'block' : 'none' }}>

--- a/packages/components/src/components/alert/style/index.less
+++ b/packages/components/src/components/alert/style/index.less
@@ -9,18 +9,11 @@
   border-radius: 6px;
   transition: all ease 0.8s;
 
-  & .gio-alert-icon {
+  & &-icon {
     flex-shrink: 0;
     align-self: flex-start;
-    width: 16px;
-    height: 16px;
-    padding-top: 3px;
-    border-radius: 8px;
-
-    svg {
-      width: 16px;
-      height: 16px;
-    }
+    height: 100%;
+    padding-top: 1px;
   }
 
   & .gio-alert-content {


### PR DESCRIPTION
affects: @gio-design/components

ISSUES CLOSED: #140

## Related issue link

https://github.com/growingio/gio-design/issues/140

## Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | add color on icon          |
| 🇨🇳 Chinese |  添加alert中icon的颜色         |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
