### PR TITLE
style(checkbox): align check icon when be used to Table

### DIFF
--- a/packages/components/src/components/checkbox/style/index.less
+++ b/packages/components/src/components/checkbox/style/index.less
@@ -40,7 +40,7 @@
 
 .@{checkbox-icon-cls} {
   position: absolute;
-  top: 6px;
+  top: 7px;
   left: 3px;
   z-index: 999;
   transform: scale(0);
@@ -79,7 +79,7 @@
   display: inline-block;
   width: 16px;
   height: 16px;
-  vertical-align: text-bottom;
+  vertical-align: middle;
 
   & + span {
     margin-left: 8px;

--- a/packages/website/src/components/functional/dropdown/demo/base.tsx
+++ b/packages/website/src/components/functional/dropdown/demo/base.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dropdown, Button } from '@gio-design/components';
-import '@gio-design/components/es/components/Dropdown/style/index.css';
+import '@gio-design/components/es/components/dropdown/style/index.css';
 
 export default () => (
   <Dropdown overlay={<div style={{ width: 200 }}>11111</div>}>

--- a/packages/website/src/components/functional/dropdown/demo/other.tsx
+++ b/packages/website/src/components/functional/dropdown/demo/other.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Dropdown, Button } from '@gio-design/components';
 import { More } from '@gio-design/icons';
-import '@gio-design/components/es/components/Dropdown/style/index.css';
+import '@gio-design/components/es/components/dropdown/style/index.css';
 
 export default () => (
   <Dropdown overlay={<div style={{ width: 200 }}>11111</div>}>


### PR DESCRIPTION
affects: @gio-design/components, website

## Related issue link

## Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  align check icon when be used to Table         |
| 🇨🇳 Chinese |   修正CheckBox 被用于 Table 时”对号“ 不居中       |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
