### PR TITLE
style: design zindex display

### DIFF
--- a/packages/components/src/components/dropdown/style/index.less
+++ b/packages/components/src/components/dropdown/style/index.less
@@ -8,7 +8,7 @@
 
 .@{dropdown-prefix-cls} {
   position: absolute;
-  z-index: 100;
+  z-index: @zindex-dropdown;
   margin: auto;
 
   &-hidden {

--- a/packages/components/src/components/popconfirm/style/index.less
+++ b/packages/components/src/components/popconfirm/style/index.less
@@ -9,7 +9,7 @@
 
 .@{popconfirm-prefix-cls} {
   position: absolute;
-  z-index: 100;
+  z-index: @zindex-popconfirm;
   margin: auto;
 
   &-hidden {

--- a/packages/components/src/components/popover/style/index.less
+++ b/packages/components/src/components/popover/style/index.less
@@ -9,7 +9,7 @@
 
 .@{popover-prefix-cls} {
   position: absolute;
-  z-index: 100;
+  z-index: @zindex-popover;
   margin: auto;
 
   &-hidden {

--- a/packages/components/src/components/table/style/index.less
+++ b/packages/components/src/components/table/style/index.less
@@ -101,7 +101,7 @@
     }
     &-fix-left,
     &-fix-right {
-      z-index: 1;
+      z-index: @zindex-table-fixed;
     }
     &-fix-left-last {
       &::after {

--- a/packages/components/src/components/tooltip/style/index.less
+++ b/packages/components/src/components/tooltip/style/index.less
@@ -9,7 +9,7 @@
 
 .@{tooltip-prefix-cls} {
   position: absolute;
-  z-index: 100;
+  z-index: @zindex-tooltip;
   max-width: 500px;
 
   &-hidden {

--- a/packages/tokens/properties/zIndex.json
+++ b/packages/tokens/properties/zIndex.json
@@ -1,0 +1,19 @@
+{
+  "zindex": {
+    "table-fixed": {
+      "value": 2
+    },
+    "popover": {
+      "value": 1030
+    },
+    "dropdown": {
+      "value": 1050
+    },
+    "popconfirm": {
+      "value": 1060
+    },
+    "tooltip": {
+      "value": 1070
+    }
+  }
+}


### PR DESCRIPTION
affects: @gio-design/components, @gio-design/tokens

从全局角度设计一下元素的层叠展示效果。
下图是ant-design的zindex token
![截屏2020-09-11 下午3 15 49](https://user-images.githubusercontent.com/29272287/92883132-2ccf7100-f443-11ea-8067-5d3cd3627464.png)

用到 zindex 的同学，思考其值并加入到token。

## Related issue link

## Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  design zindex display         |
| 🇨🇳 Chinese |   设计 zindex 排列        |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
