### PR TITLE
fix(avatar): fix avatar can't trigger Dropdown

### DIFF
--- a/packages/components/src/components/avatar/Avatar.tsx
+++ b/packages/components/src/components/avatar/Avatar.tsx
@@ -4,8 +4,9 @@ import { More } from '@gio-design/icons';
 import Tooltip from '../tooltip';
 import { AvatarProps } from './interface';
 import { ConfigContext } from '../config-provider';
+import composeRef from '../../utils/composeRef';
 
-const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
+const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProps, ref: React.Ref<HTMLSpanElement>) => {
   const {
     className,
     size = 'default',
@@ -16,12 +17,15 @@ const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
     displayTooltip = false,
     prefixCls: customizePrefixCls,
     placement = 'bottom',
+    ...rest
   } = props;
+
   const { getPrefixCls } = useContext(ConfigContext);
   const [isImgExist, setIsImgExist] = useState<boolean>(src !== undefined);
   const [scale, setScale] = useState<number>(1);
   const nodeRef = useRef<HTMLSpanElement>(null);
   const childrenRef = useRef<HTMLSpanElement>(null);
+  const mergedRef = composeRef(ref, nodeRef);
 
   useEffect(() => {
     if (nodeRef.current && childrenRef.current) {
@@ -79,11 +83,11 @@ const Avatar: React.FC<AvatarProps> = (props: AvatarProps) => {
     );
 
   return renderTooltip(
-    <span ref={nodeRef} className={classString}>
+    <span ref={mergedRef} className={classString} {...rest}>
       {renderMore()}
       {renderAvatar()}
     </span>
   );
-};
+});
 
 export default Avatar;

--- a/packages/components/src/components/avatar/__tests__/__snapshots__/AvatarGroup.test.js.snap
+++ b/packages/components/src/components/avatar/__tests__/__snapshots__/AvatarGroup.test.js.snap
@@ -6,6 +6,7 @@ exports[`Testing AvatarGroup should be stable 1`] = `
 >
   <span
     className="gio-avatar gio-avatar-df"
+    name="li"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -17,6 +18,7 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
+    name="pan"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -32,6 +34,7 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
+    name="leng"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -43,6 +46,7 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
+    name="liu"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/components/src/utils/composeRef.ts
+++ b/packages/components/src/utils/composeRef.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const composeRef = <T>(...refs: React.Ref<T>[]): React.RefCallback<T> => (node: T) => {
+  refs.forEach((ref) => {
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (typeof ref === 'object' && ref && 'current' in ref) {
+      (ref as any).current = node;
+    }
+  });
+};
+
+export default composeRef;


### PR DESCRIPTION
affects: @gio-design/components

修复avatar组件不能被Dropdown等组件触发的bug。
所有需要触发tooltip、Popconfirm、Popover、Dropdown的组件都需要解构参数，并传rest给return的元素。


## Related issue link
## Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |    fix avatar can't trigger Dropdown        |
| 🇨🇳 Chinese |  修复avatar组件不能触发Dropdown 的bug  |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
