### PR TITLE
style(checkbox): advance .gio-checkbox-icon-indeterminate style priority

### DIFF
--- a/packages/components/src/components/checkbox/style/index.less
+++ b/packages/components/src/components/checkbox/style/index.less
@@ -132,7 +132,7 @@
     }
   }
 
-  &-indeterminate {
+  .gio-icon&-indeterminate {
     .@{checkbox-inner-prefix-cls} {
       &::after {
         transform: scale(1);


### PR DESCRIPTION
affects: @gio-design/components

advance .gio-checkbox-icon-indeterminate style priority

## Related issue link



## Changelog


| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  advance .gio-checkbox-icon-indeterminate style priority         |
| 🇨🇳 Chinese | 提升 .gio-checkbox-icon-indeterminate 样式优先级          |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
