### PR TITLE
feat(input): value and onChange prop is optional

### DIFF
--- a/packages/components/src/components/input/InputNumber.tsx
+++ b/packages/components/src/components/input/InputNumber.tsx
@@ -31,18 +31,18 @@ const InputNumber: React.FC<InputProps> = ({
     if (isNaN(v) || v < min || v > max) {
       return;
     }
-    onChange(value);
+    onChange?.(value);
   };
 
   const handleAdd = () => {
     if (!addDisabled) {
-      onChange(String(Number(value) + 1));
+      onChange?.(String(Number(value) + 1));
     }
   };
 
   const handleDecrease = () => {
     if (!decreaseDisabled) {
-      onChange(String(Number(value) - 1));
+      onChange?.(String(Number(value) - 1));
     }
   };
 

--- a/packages/components/src/components/input/hooks/useEnter.tsx
+++ b/packages/components/src/components/input/hooks/useEnter.tsx
@@ -6,7 +6,7 @@ interface UseEnterResult {
   handleOnChange: (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => void;
 }
 
-type UseEnter = (value: string, onChange: (e: string) => void) => UseEnterResult;
+type UseEnter = (value: string | undefined, onChange: ((e: string) => void) | undefined) => UseEnterResult;
 
 const delay = 500;
 
@@ -14,7 +14,9 @@ const useEnter: UseEnter = (value, onChange) => {
   const [realTimeValue, setRealTimeValue] = React.useState('');
 
   React.useEffect(() => {
-    setRealTimeValue(value);
+    if (typeof value === 'string') {
+      setRealTimeValue(value);
+    }
   }, [value]);
 
   useDebounce(

--- a/packages/components/src/components/input/interfaces.ts
+++ b/packages/components/src/components/input/interfaces.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'value' | 'onChange'> {
-  value: string;
-  onChange: (value: string) => void;
+  value?: string;
+  onChange?: (value: string) => void;
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onPressEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
@@ -17,8 +17,8 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 }
 
 export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value' | 'onChange'> {
-  value: string;
-  onChange: (value: string) => void;
+  value?: string;
+  onChange?: (value: string) => void;
   resize?: boolean;
   inputStyle?: React.CSSProperties;
   wrapStyle?: React.CSSProperties;

--- a/packages/website/src/components/basic/input/demo/Input.tsx
+++ b/packages/website/src/components/basic/input/demo/Input.tsx
@@ -21,7 +21,7 @@ export default () => {
         placeholder="禁止输入"
         value={inputValue2}
         onChange={setInputValue2}
-        disabled={true}
+        disabled
         wrapStyle={{ display: 'block', marginBottom: '20px' }}
       />
 


### PR DESCRIPTION
affects: @gio-design/components, website

ISSUES CLOSED: #217

## Related issue link
#217 

## Changelog
value and onChange prop is optional

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |  value and onChange prop is optional         |
| 🇨🇳 Chinese |   value和 onChange 参数是可选的        |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
