### PR TITLE
fix(table): some state of pagination not reset when dataSource update

### DIFF
--- a/packages/components/src/components/table/hook/usePagination.tsx
+++ b/packages/components/src/components/table/hook/usePagination.tsx
@@ -17,15 +17,17 @@ const usePagination = <RecordType,>(
 ] => {
   const { current, pageSize, total, ...rest } = pagination || {};
   const [localCurrent, setLocalCurrent] = useControlledState<number>(current, 1);
-  const [localPageSize] = useControlledState<number>(pageSize, 10);
+  const [localPageSize, setLocalPageSize] = useControlledState<number>(pageSize, 10);
   const [controlledTotal, setControlledTotal] = useControlledState<number>(total, data.length);
 
   // when dataSource update && unControlled, Pagination update.
   useEffect(() => {
     if (isUndefined(total)) {
       setControlledTotal(data.length, true);
+      setLocalCurrent(1, true);
+      setLocalPageSize(10, true);
     }
-  }, [data.length, total]);
+  }, [data, total]);
 
   // 通过total字段是否受控判断是否后端分页。
   const paginationData = useMemo(

--- a/packages/website/src/components/functional/table/index.zh-CN.md
+++ b/packages/website/src/components/functional/table/index.zh-CN.md
@@ -165,23 +165,23 @@ group:
 
 ### Table
 
-| 参数             | 说明                                                                                                               | 类型                                   | 默认值               |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------- | -------------------- |
-| **title**        | 列表标题                                                                                                           | string                                 |                      |
-| **columns**      | 列表列的配置描述，具体项见下表                                                                                     | ColumnsType[]                          | -                    |
-| **dataSource**   | 数据数组                                                                                                           | object[]                               | -                    |
-| **pagination**   | 设置分页 ，默认开启，设置为 false 时关闭分页。具体参数可见[pagination](/components/functional/pagination#参数说明) | PaginationProps \| false               | {}                   |
-| **rowSelection** | 设置行选择功能                                                                                                     | RowSelection                           | -                    |
-| **scroll**       | 设置 table 横向纵向滚动                                                                                            | { x: number, y:number}                 | { x: false, y:false} |
-| **showIndex**    | 设置显示序号                                                                                                       | boolean                                | false                |
-| **emptyText**    | 设置搜索无结果时的样式                                                                                             | React.ReactNode                        | -                    |
-| **onChange**     | 触发分页、排序、过滤时的回调                                                                                       | (pagination, sorter, filters,) => void | -                    |
-| **rowKey**       | 表格行 key 的取值，可以是字符串或一个函数                                                                          | string \| function(record): string     | 数据的 key 字段      |
-| **rowClassName** | 表格行的类名                                                                                                       | function(record, index): string        | -                    |
-| **onRow**        | 设置行属性                                                                                                         | function(record, index)                | -                    |
-| **onHeaderRow**  | 设置头部行属性                                                                                                     | function(column, index)                | -                    |
-| **showHover**    | 是否显示 hover 效果                                                                                                | boolean                                | true                 |
-| **showHeader**   | 是否显示 table head                                                                                                | boolean                                | true                 |
+| 参数             | 说明                                           | 类型                                   | 默认值               |
+| ---------------- | ---------------------------------------------- | -------------------------------------- | -------------------- |
+| **title**        | 列表标题                                       | string                                 |                      |
+| **columns**      | 列表列的配置描述，具体项见下表                 | ColumnsType[]                          | -                    |
+| **dataSource**   | 数据数组                                       | object[]                               | -                    |
+| **pagination**   | 设置分页 ，默认开启，设置为 false 时关闭分页。 | PaginationProps \| false               | {}                   |
+| **rowSelection** | 设置行选择功能                                 | RowSelection                           | -                    |
+| **scroll**       | 设置 table 横向纵向滚动                        | { x: number, y:number}                 | { x: false, y:false} |
+| **showIndex**    | 设置显示序号                                   | boolean                                | false                |
+| **emptyText**    | 设置搜索无结果时的样式                         | React.ReactNode                        | -                    |
+| **onChange**     | 触发分页、排序、过滤时的回调                   | (pagination, sorter, filters,) => void | -                    |
+| **rowKey**       | 表格行 key 的取值，可以是字符串或一个函数      | string \| function(record): string     | 数据的 key 字段      |
+| **rowClassName** | 表格行的类名                                   | function(record, index): string        | -                    |
+| **onRow**        | 设置行属性                                     | function(record, index)                | -                    |
+| **onHeaderRow**  | 设置头部行属性                                 | function(column, index)                | -                    |
+| **showHover**    | 是否显示 hover 效果                            | boolean                                | true                 |
+| **showHeader**   | 是否显示 table head                            | boolean                                | true                 |
 
 ### Column
 
@@ -216,3 +216,7 @@ group:
 | **columnWidth**     | 设置选择列宽                       | number \| string                                                | 48     |
 | **onChange**        | 选择项改变时触发的回调函数         | (selectedRowKeys: string[], selectedRows: RecordType[]) => void | -      |
 | **fixed**           | 固定选择列                         | 'left' \| 'right' \|boolean                                     | -      |
+
+### Pagination
+
+具体参数可见[pagination](/components/functional/pagination#参数说明)， 目前是通过 total 字段来判断分页是否受控。通过设置 total 以及其他字段用来做服务端分页。


### PR DESCRIPTION
affects: @gio-design/components

some state of pagination not reset when dataSource update.
when table dataSource update, all state of pagination should be reset.

## Related issue link

<!--
Describe the source of requirement, like related issue link.
-->

## Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | when table dataSource update, all state of pagination should be reset.          |
| 🇨🇳 Chinese |   当table的DataSource改变的时候，所有列表分页的状态都应该被重置。   |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
