### PR TITLE
fix(upload): upload组件增加一个可选参数successBorder，控制图片上传成功后边框是否显示

### DIFF
--- a/packages/components/src/components/upload/Upload.tsx
+++ b/packages/components/src/components/upload/Upload.tsx
@@ -33,6 +33,7 @@ const triggerMap: ITriggerMap = {
 };
 
 const Upload: React.FC<IUploadProps> = ({
+  successBorder = false,
   style,
   prefixCls: customPrefixCls,
   className,
@@ -57,7 +58,11 @@ const Upload: React.FC<IUploadProps> = ({
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('upload', customPrefixCls);
 
-  const rootCls = classnames(className, prefixCls, {
+  const rootCls = classnames(className, prefixCls, successBorder ? {
+    [`${prefixCls}--disabled`]: disabled,
+    [`${prefixCls}--success-border`]: file?.status === STATUS_SUCCESS,
+    [`${prefixCls}--error`]: file?.status === STATUS_ERROR,
+    } : {
     [`${prefixCls}--disabled`]: disabled,
     [`${prefixCls}--success`]: file?.status === STATUS_SUCCESS,
     [`${prefixCls}--error`]: file?.status === STATUS_ERROR,
@@ -94,7 +99,7 @@ const Upload: React.FC<IUploadProps> = ({
       response,
       status: STATUS_SUCCESS,
     };
-
+    
     try {
       if (fileOnSuccess.type.startsWith('image/')) {
         dataUrl = await imageFile2DataUrl(fileOnSuccess);

--- a/packages/components/src/components/upload/interface.ts
+++ b/packages/components/src/components/upload/interface.ts
@@ -65,6 +65,8 @@ export interface IInnerTriggerProps {
 }
 
 export interface IUploadProps<T = any> {
+  // 上传的图片是否显示边框
+  successBorder ?: boolean;
   // upload 组件展现类型
   type?: TUploadType;
   // input 时希望使用 file 还是直接使用 url

--- a/packages/components/src/components/upload/style/index.less
+++ b/packages/components/src/components/upload/style/index.less
@@ -33,6 +33,17 @@
       }
     }
   }
+  &--success-border {
+    & .@{gio-upload-card},
+    & .@{gio-upload-avatar},
+    & .@{gio-upload-drag} {
+      border: 1px solid #dcdfed;
+
+      &:hover .@{gio-upload-actions} {
+        opacity: 1;
+      }
+    }
+  }
 
   &--disabled {
     & .@{gio-upload-card},

--- a/packages/website/src/components/functional/upload/demos/card.tsx
+++ b/packages/website/src/components/functional/upload/demos/card.tsx
@@ -5,7 +5,7 @@ import { props, action } from './commonSets';
 
 export default () => (
   <div>
-    <Upload type="card" style={{ margin: '0 5px' }} action={action} {...props} />
-    <Upload type="card" style={{ margin: '0 5px' }} {...props} />
+    <Upload type="card" style={{ margin: '0 5px' }} action={action} {...props} successBorder />
+    <Upload type="card" style={{ margin: '0 5px' }} {...props} successBorder />
   </div>
 );


### PR DESCRIPTION
affects: @gio-design/components, website

Upload组件增加一个可选参数successBorder，控制图片上传成功后边框是否显示，默认为false

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

## Related issue link

<!--
Describe the source of requirement, like related issue link.
-->

## Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      An optional parameter successBorder is added to the upload component to control whether the border is displayed after the image is uploaded successfully. The default value is false     |
| 🇨🇳 Chinese |     Upload组件增加一个可选参数successBorder，控制图片上传成功后边框是否显示，默认为false      |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
