### PR TITLE
fix(dropdown): 修复Dropdown组件中placement方向的问题，由12个方向改为只有上下6个方向可选，默认方向为下

### DIFF
--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -1,11 +1,12 @@
 import React, { useContext, cloneElement } from 'react';
+import { isFunction } from 'lodash';
 import Tooltip from '../tooltip';
 import { DropdownProps } from './interface';
 import { ConfigContext } from '../config-provider';
 import useControlledState from '../../utils/hooks/useControlledState';
-import { isFunction } from 'lodash';
 
 const Dropdown = (props: DropdownProps) => {
+  const placementList = ['top','bottom','topLeft','topRight','bottomLeft','bottomRight'];
   const {
     children,
     prefixCls: customizePrefixCls,
@@ -33,7 +34,7 @@ const Dropdown = (props: DropdownProps) => {
     <Tooltip
       prefixCls={prefixCls}
       trigger={trigger}
-      placement={placement}
+      placement={placementList.includes(placement) ? placement : 'bottom'}
       visible={controlledVisible}
       overlay={getOverlay()}
       onVisibleChange={(_visible) => {

--- a/packages/website/src/components/functional/dropdown/demo/base.tsx
+++ b/packages/website/src/components/functional/dropdown/demo/base.tsx
@@ -4,7 +4,7 @@ import '@gio-design/components/es/components/dropdown/style/index.css';
 
 export default () => (
   <Dropdown
-    overlay={
+    overlay={(
       <div
         style={{
           width: 294,
@@ -19,7 +19,7 @@ export default () => (
       >
         内容区域
       </div>
-    }
+    )}
     placement="bottomRight"
   >
     <Button type="secondary">更多操作</Button>


### PR DESCRIPTION
affects: @gio-design/components, website

修复Dropdown组件中placement方向的问题，由12个方向改为只有上下6个方向可选，默认方向为下

<!--
First of all, thank you for your contribution! 😄

New feature please send pull request to feature branch, and rest to master branch.
Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!
-->

## Related issue link

<!--
Describe the source of requirement, like related issue link.
-->

## Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      Fixed the placement direction problem in the Dropdown component. From 12 directions to 6 directions, the default direction is down     |
| 🇨🇳 Chinese |     修复Dropdown组件中placement方向的问题，由12个方向改为只有上下6个方向可选，默认方向为下      |

## Self check

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed
