### PR TITLE
fix(search bar): 解决Search Bar组件size=large或者small的时候，右侧放大镜icon垂直方向没有居中的问题

### DIFF
--- a/packages/components/src/components/search-bar/__tests__/__snapshots__/searchbar.test.js.snap
+++ b/packages/components/src/components/search-bar/__tests__/__snapshots__/searchbar.test.js.snap
@@ -29,7 +29,7 @@ initialize {
               "children": Array [
                 Object {
                   "attribs": Object {
-                    "class": "gio-icon gio-searchbar-suffix-search",
+                    "class": "gio-icon gio-searchbar-suffix-search-large",
                   },
                   "children": Array [
                     Object {
@@ -304,7 +304,7 @@ initialize {
             "children": Array [
               Object {
                 "attribs": Object {
-                  "class": "gio-icon gio-searchbar-suffix-search",
+                  "class": "gio-icon gio-searchbar-suffix-search-large",
                 },
                 "children": Array [
                   Object {

--- a/packages/components/src/components/search-bar/index.tsx
+++ b/packages/components/src/components/search-bar/index.tsx
@@ -96,6 +96,12 @@ const SearchBar: React.FC<SearchBarProps> = ({
         <CloseCircleFilled className={`${prefixCls}-suffix-close`} onClick={handleClearValue} />
       ) : null;
     }
+    if(size === "large"){
+      return <SearchOutlined className={`${prefixCls}-suffix-search-large`} />;
+    }
+    if(size === "small"){
+      return <SearchOutlined className={`${prefixCls}-suffix-search-small`} />;
+    }
     return <SearchOutlined className={`${prefixCls}-suffix-search`} />;
   };
 

--- a/packages/components/src/components/search-bar/style/index.less
+++ b/packages/components/src/components/search-bar/style/index.less
@@ -51,9 +51,16 @@
       color: @palette-black-6;
       cursor: pointer;
     }
-
     &-search {
       color: @palette-gray-6;
+    }
+    &-search-large {
+      color: @palette-gray-6;
+      vertical-align: middle;
+    }
+    &-search-small {
+      color: @palette-gray-6;
+      vertical-align: inherit;
     }
   }
 }

--- a/packages/website/src/components/functional/searchBar/demo/index.tsx
+++ b/packages/website/src/components/functional/searchBar/demo/index.tsx
@@ -5,5 +5,15 @@ import '@gio-design/components/es/components/search-bar/style/index.less';
 export default () => {
   const [value, setValue] = React.useState('');
 
-  return <SearchBar showStorage showClear allowClearStorage value={value} onChange={setValue} id="demo1" />;
+  return (
+    <SearchBar
+      showStorage
+      showClear
+      allowClearStorage
+      value={value}
+      onChange={setValue}
+      id="demo1"
+      size="medium"
+    />
+  );
 };


### PR DESCRIPTION
affects: @gio-design/components, website

解决Search Bar组件size=large或者small的时候，右侧放大镜icon垂直方向没有居中的问题

## Changelog

<!--
Describe changes from userside, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |      When the search bar component size = large or small, the vertical direction of the right magnifying glass icon is not centered     |
| 🇨🇳 Chinese |     解决Search Bar组件size=large或者small的时候，右侧放大镜icon垂直方向没有居中的问题      |