### PR TITLE
docs(release): @gio-design/components 20.10.5 change log

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/components",
-  "version": "20.10.4",
+  "version": "20.10.5",
   "description": "GrowingIO Design components",
   "author": "GrowingIO Frontend Team <eng-frontend@growingio.com>",
   "module": "./es/index.js",
@@ -20,7 +20,7 @@
     "test:xunit": "JEST_JUNIT_CLASSNAME=\"{filename}\" jest --ci --testResultsProcessor=jest-junit"
   },
   "dependencies": {
-    "@gio-design/icons": "^20.10.4",
+    "@gio-design/icons": "^20.10.5",
     "@gio-design/tokens": "^20.9.4",
     "@types/classnames": "^2.2.9",
     "@types/lodash": "^4.14.136",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/icons",
-  "version": "20.10.4",
+  "version": "20.10.5",
   "description": "GrowingIO Design semantic vector icons",
   "author": "GrowingIO Frontend Team <eng-frontend@growingio.com>",
   "homepage": "https://growingio.design/resources/icons",

--- a/packages/website/src/develop/changelog/components.en-US.md
+++ b/packages/website/src/develop/changelog/components.en-US.md
@@ -9,6 +9,20 @@ nav:
 
 # @gio-design/components Change Log
 
+## 20.10.5
+
+- Grid
+  - 🆕add gio-grid component [#338](https://github.com/growingio/gio-design/pull/338)
+- Form
+  - 🐛fix colon not render issue [#340](https://github.com/growingio/gio-design/pull/340)
+- Dropdown
+  - 💄Fixed the placement direction problem in the Dropdown component. From 12 directions to 6 directions, the default direction is down [#333](https://github.com/growingio/gio-design/pull/333/)
+- Upload
+  - 🆕An optional parameter successBorder is added to the upload component to control whether the border is displayed after the image is uploaded successfully. The default value is false [#331](https://github.com/growingio/gio-design/pull/331)
+- Select
+  - 💄The text size in the input selection box of the select component is defined [#337](https://github.com/growingio/gio-design/pull/337)
+
+
 ## 20.10.4
 
 - Select

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -9,6 +9,19 @@ nav:
 
 # @gio-design/components 更新日志
 
+## 20.10.5
+
+- Grid
+  - 🆕 新增Grid组件 [#338](https://github.com/growingio/gio-design/pull/338)
+- Form
+  - 🐛修复colon不渲染的问题 [#340](https://github.com/growingio/gio-design/pull/340)
+- Dropdown
+  - 💄placement由12个方向改为只有上下6个方向可选，默认方向为下 [#333](https://github.com/growingio/gio-design/pull/333/)
+- Upload
+  - 🆕增加一个可选参数successBorder，控制图片上传成功后边框是否显示 [#331](https://github.com/growingio/gio-design/pull/331)
+- Select
+  - 💄定义了select组件中input选择框内的文字尺寸 [#337](https://github.com/growingio/gio-design/pull/337)
+
 ## 20.10.4
 
 - Select

--- a/packages/website/src/develop/changelog/icons.en-US.md
+++ b/packages/website/src/develop/changelog/icons.en-US.md
@@ -9,6 +9,16 @@ nav:
 
 # @gio-design/icons Change Log
 
+## 20.10.5
+
+- 🆕 add [#349](https://github.com/growingio/gio-design/pull/349)
+
+  - `CopyOutlined`
+  - `DownloadOutlined`
+  - `InformationCircleOutlined`
+  - `SequenceOutlined`
+  - `ShareOutlined`
+
 ## 20.10.4
 
 - 🆕 add [#319](https://github.com/growingio/gio-design/pull/319)

--- a/packages/website/src/develop/changelog/icons.zh-CN.md
+++ b/packages/website/src/develop/changelog/icons.zh-CN.md
@@ -9,6 +9,16 @@ nav:
 
 # @gio-design/icons 更新日志
 
+## 20.10.5
+
+- 🆕 新增[#349](https://github.com/growingio/gio-design/pull/349)
+
+  - `CopyOutlined`
+  - `DownloadOutlined`
+  - `InformationCircleOutlined`
+  - `SequenceOutlined`
+  - `ShareOutlined`
+
 ## 20.10.4
 
 - 🆕 新增 [#319](https://github.com/growingio/gio-design/pull/319)


### PR DESCRIPTION
# @gio-design/components 更新日志

## 20.10.5

- Grid
  - 🆕 新增Grid组件 [#338](https://github.com/growingio/gio-design/pull/338)
- Form
  - 🐛修复colon不渲染的问题 [#340](https://github.com/growingio/gio-design/pull/340)
- Dropdown
  - 💄placement由12个方向改为只有上下6个方向可选，默认方向为下 [#333](https://github.com/growingio/gio-design/pull/333/)
- Upload
  - 🆕增加一个可选参数successBorder，控制图片上传成功后边框是否显示 [#331](https://github.com/growingio/gio-design/pull/331)
- Select
  - 💄定义了select组件中input选择框内的文字尺寸 [#337](https://github.com/growingio/gio-design/pull/337)

# @gio-design/icons 更新日志

## 20.10.5

- 🆕 新增[#349](https://github.com/growingio/gio-design/pull/349)

  - `CopyOutlined`
  - `DownloadOutlined`
  - `InformationCircleOutlined`
  - `SequenceOutlined`
  - `ShareOutlined`