### PR TITLE
docs(release): @gio-design/components 20.10.6 change log

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/components",
-  "version": "20.10.5",
+  "version": "20.10.6",
   "description": "GrowingIO Design components",
   "author": "GrowingIO Frontend Team <eng-frontend@growingio.com>",
   "module": "./es/index.js",

--- a/packages/website/src/develop/changelog/components.en-US.md
+++ b/packages/website/src/develop/changelog/components.en-US.md
@@ -9,6 +9,20 @@ nav:
 
 # @gio-design/components Change Log
 
+## 20.10.6
+
+- component
+  - 🆕 support placholderImg in avatar and card Upload [#379](https://github.com/growingio/gio-design/pull/379)
+  - 🛎 support async function in StepModal's step change [#378](https://github.com/growingio/gio-design/pull/378)
+- popconfirm
+  - remove code associated with disabled [#377](https://github.com/growingio/gio-design/pull/377)
+- tootip
+  - 🆕 add disabled parameter [#367](https://github.com/growingio/gio-design/pull/367)
+- input
+  - change Input component is controlled component，and other website demo，unit test. and style parameter fix [#374](https://github.com/growingio/gio-design/pull/374)
+- Table
+  - Fix mouse hover will change color when the table content is empty. Define the relationship with the render method when ellipsis。[#334](https://github.com/growingio/gio-design/pull/334)
+
 ## 20.10.5
 
 - Grid

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -9,6 +9,20 @@ nav:
 
 # @gio-design/components 更新日志
 
+## 20.10.6
+
+- component
+  - 🆕 avatar, card类型的 Upload 支持 placeholderImg 展示 [#379](https://github.com/growingio/gio-design/pull/379)
+  - 🛎 StepModal 的 onNext, onBack 支持异步调用，可打断下一步的执行 [#378](https://github.com/growingio/gio-design/pull/378)
+- popconfirm
+  - 去掉跟disabled相关的代码 [#377](https://github.com/growingio/gio-design/pull/377)
+- tootip
+  - 🆕 新增 disabled 参数 [#367](https://github.com/growingio/gio-design/pull/367)
+- input
+  - 修改Input组件为受控组件，以及相关website demo，unit test, 样式不再固定为300px [#374](https://github.com/growingio/gio-design/pull/374)
+- Table
+  - 修复当Table内容为空时，鼠标hover 会变色的问题。定义当设置ellipsis时与render方法之间的关系。[#334](https://github.com/growingio/gio-design/pull/334)
+
 ## 20.10.5
 
 - Grid


### PR DESCRIPTION
# @gio-design/components 更新日志

## 20.10.6

- component
  - 🆕 avatar, card类型的 Upload 支持 placeholderImg 展示 [#379](https://github.com/growingio/gio-design/pull/379)
  - 🛎 StepModal 的 onNext, onBack 支持异步调用，可打断下一步的执行 [#378](https://github.com/growingio/gio-design/pull/378)
- popconfirm
  - 去掉跟disabled相关的代码 [#377](https://github.com/growingio/gio-design/pull/377)
- tootip
  - 🆕 新增 disabled 参数 [#367](https://github.com/growingio/gio-design/pull/367)
- input
  - 🛎 修改Input组件为受控组件，以及相关website demo，unit test, 样式不再固定为300px [#374](https://github.com/growingio/gio-design/pull/374)
- Table
  - 🐛 修复当Table内容为空时，鼠标hover 会变色的问题。定义当设置ellipsis时与render方法之间的关系。[#334](https://github.com/growingio/gio-design/pull/334)
