### PR TITLE
fix(search-bar): let the display panel adapt to the width of input

### DIFF
--- a/packages/components/src/components/search-bar/index.tsx
+++ b/packages/components/src/components/search-bar/index.tsx
@@ -96,13 +96,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         <CloseCircleFilled className={`${prefixCls}-suffix-close`} onClick={handleClearValue} />
       ) : null;
     }
-    if(size === "large"){
-      return <SearchOutlined className={`${prefixCls}-suffix-search-large`} />;
-    }
-    if(size === "small"){
-      return <SearchOutlined className={`${prefixCls}-suffix-search-small`} />;
-    }
-    return <SearchOutlined className={`${prefixCls}-suffix-search`} />;
+    return <SearchOutlined className={`${prefixCls}-suffix-search-${size}`} />;
   };
 
   const renderStorage = () => {

--- a/packages/components/src/components/search-bar/style/index.less
+++ b/packages/components/src/components/search-bar/style/index.less
@@ -4,13 +4,18 @@
 
 .@{searchbar-prefix-cls} {
   position: relative;
+  width: fit-content;
+
+  .gio-input {
+    width: inherit;
+  }
 
   &-dropdown {
     position: absolute;
     top: 45px;
     left: 0;
     z-index: 10000;
-    min-width: 300px;
+    width: 100%;
     height: 240px;
     padding: 8px;
     overflow-y: auto;
@@ -25,8 +30,11 @@
       height: 40px;
       padding: 9px 16px;
       &-text {
+        overflow: hidden;
         color: @palette-black-2;
         font-size: @size-font-12;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
     }
 
@@ -51,7 +59,7 @@
       color: @palette-black-6;
       cursor: pointer;
     }
-    &-search {
+    &-search-medium {
       color: @palette-gray-6;
     }
     &-search-large {


### PR DESCRIPTION
affects: @gio-design/components

let the display panel adapt to the width of input

## @gio-design/components@20.10.6

- 搜索框
  - 让展示面板自适应input的宽度，并且让提示文字在宽度过小时超出部分显示 ...

---

## @gio-design/components@20.10.6

- Search Bar
  - Let the display panel adapt to the width of input,and let the prompt text show '...' when the width is too short
