### PR TITLE
fix(date-picker): solve global cover of '.gio-input' in date-picker

### DIFF
--- a/packages/components/src/components/date-picker/__tests__/__snapshots__/data-picker.spec.js.snap
+++ b/packages/components/src/components/date-picker/__tests__/__snapshots__/data-picker.spec.js.snap
@@ -4,7 +4,7 @@ exports[`DatePicker should match snapshot 1`] = `
 initialize {
   "0": Object {
     "attribs": Object {
-      "class": "",
+      "class": "gio-date-picker-container",
     },
     "children": Array [
       Object {

--- a/packages/components/src/components/date-picker/datePicker.tsx
+++ b/packages/components/src/components/date-picker/datePicker.tsx
@@ -103,7 +103,7 @@ const DatePicker: React.FC<DatePickerProps> = (props: DatePickerProps) => {
   );
 
   return (
-    <div className={classNames('')}>
+    <div className={classNames(`${prefixCls}-container`)}>
       <RcDatePicker
         calendar={calendar}
         value={localValue}

--- a/packages/components/src/components/date-picker/style/index.less
+++ b/packages/components/src/components/date-picker/style/index.less
@@ -12,9 +12,11 @@
   z-index: @zindex-dropdown;
 }
 
-.gio-input {
-  width: 253px;
-  height: 40px;
+.@{date-picker-prefix-cls}-container {
+  .gio-input {
+    width: 280px;
+    height: 40px;
+  }
 }
 
 .@{date-picker-prefix-cls}-range-input {

--- a/packages/components/src/components/input/style/index.less
+++ b/packages/components/src/components/input/style/index.less
@@ -8,6 +8,8 @@
 
 .@{input-prefix-cls} {
   display: inline-block;
+  width: 253px;
+  height: 40px;
 
   &-textarea {
     height: 80px;


### PR DESCRIPTION
affects: @gio-design/components

solve global cover of '.gio-input' in date-picker

## @gio-design/components@20.10.6

- 日期选择器/输入框
  - 解决date-picker组件中.gio-input样式产生全局覆盖的问题，在input组件中定义.gio-input样式

---

## @gio-design/components@20.10.6

- date-picker/input
  - To solve the global coverage problem of '.gio-input' style in date-picker component, define '.gio-input' style in input component
