### PR TITLE
refactor(list): support string type of width in component list 

### DIFF
--- a/packages/components/src/components/list/interface.ts
+++ b/packages/components/src/components/list/interface.ts
@@ -7,7 +7,7 @@ export interface IBaseListProps {
   isMultiple?: boolean;
   onChange?: (value: any) => void;
   value?: any;
-  width?: number;
+  width?: number | string;
   height?: number;
   wrapStyle?: CSSProperties;
   prefixCls?: string;
@@ -37,7 +37,7 @@ export interface SelectCoreProps {
   isMultiple: boolean;
   allowDuplicate?: boolean;
   max?: number;
-  width?: number;
+  width?: number | string;
   height?: number;
   rowHeight?: number | ((option: any) => number);
   isLoading?: boolean;
@@ -65,7 +65,7 @@ export interface SelectListProps {
   allowDuplicate?: boolean;
   required?: boolean;
   max?: number;
-  width: number;
+  width: number | string;
   height: number;
   rowHeight: number | ((option: any) => number);
   onSelect?: (value: any, selectedValue?: any | any[], option?: any) => void;

--- a/packages/components/src/components/list/list.tsx
+++ b/packages/components/src/components/list/list.tsx
@@ -8,6 +8,7 @@ import { SelectListProps } from './interface';
 
 interface State {
   value: any | any[];
+  width: number;
 }
 
 class SelectList extends React.Component<SelectListProps, {}> {
@@ -20,11 +21,16 @@ class SelectList extends React.Component<SelectListProps, {}> {
   public ref: React.RefObject<HTMLDivElement>;
   public state: State = {
     value: null,
+    width: 0,
   };
 
   public constructor(props: SelectListProps) {
     super(props);
     this.ref = React.createRef();
+  }
+
+  public componentDidMount() {
+    this.setState({ width: this.ref.current?.offsetWidth });
   }
 
   public render() {
@@ -49,7 +55,7 @@ class SelectList extends React.Component<SelectListProps, {}> {
     return (
       <List
         value={this.props.value}
-        width={width}
+        width={typeof width === 'number' ? width : this.state.width}
         height={height}
         rowCount={this.props.options.length}
         rowHeight={typeof rowHeight === 'function' ? getRowHeight : rowHeight}

--- a/packages/website/src/components/functional/list/index.zh-CN.md
+++ b/packages/website/src/components/functional/list/index.zh-CN.md
@@ -53,7 +53,7 @@ group:
 | dataSource    | `list`数据源            | Option[]                                                                    |
 | isMultiple    | 是否多选                | boolean                                                                     | false    |
 | onChange      | 选中触发的回调          | (option: value) => void                                                     | noop     |
-| width         | 列表宽度                | number                                                                      | -        |
+| width         | 列表宽度                | number \| string                                                            | -        |
 | height        | 列表高度                | number                                                                      | 400      |
 | wrapStyle     | 包裹样式                | React.CSSProperties                                                         | -        |
 | prefixCls     | 前缀`className`样式类名 | string                                                                      | gio-list |


### PR DESCRIPTION
affects: @gio-design/components, website

ISSUES CLOSED: #321

## @gio-design/components

- list组件
  - width支持string类型

---

## @gio-design/components

- Component list
  - support string type of width
