### PR TITLE
refactor(tokens): replace rem to px

### DIFF
--- a/packages/components/src/components/date-picker/style/index.less
+++ b/packages/components/src/components/date-picker/style/index.less
@@ -23,7 +23,7 @@
   align-items: center;
   width: 252px;
   border: 1px solid @color-border-input-normal;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   transition: all 0.3s ease-in-out;
 
   .gio-input {
@@ -226,7 +226,7 @@
     height: 240px;
     padding: 12px 13px;
     border: 1px solid @color-background-date-picker-hover;
-    border-radius: 0.25rem;
+    border-radius: 4px;
   }
 
   table {

--- a/packages/components/src/components/progress/style/index.less
+++ b/packages/components/src/components/progress/style/index.less
@@ -63,7 +63,7 @@
   }
 
   &-info {
-    width: 6rem;
+    width: 96px;
     margin-left: @size-spacing-m;
     white-space: nowrap;
   }

--- a/packages/tokens/properties/radius.json
+++ b/packages/tokens/properties/radius.json
@@ -5,13 +5,13 @@
         "value": "50%"
       },
       "small": {
-        "value": "0.25rem"
+        "value": "4px"
       },
       "medium": {
-        "value": "0.375rem"
+        "value": "6px"
       },
       "large": {
-        "value": "0.5rem"
+        "value": "8px"
       },
       "pill": {
         "value": "50%"

--- a/packages/tokens/properties/size/font.json
+++ b/packages/tokens/properties/size/font.json
@@ -2,40 +2,40 @@
   "size": {
     "font": {
       "10": {
-        "value": "0.625rem"
+        "value": "10px"
       },
       "12": {
-        "value": "0.75rem"
+        "value": "12px"
       },
       "14": {
-        "value": "0.875rem"
+        "value": "14px"
       },
       "16": {
-        "value": "1rem"
+        "value": "16px"
       },
       "18": {
-        "value": "1.125rem"
+        "value": "18px"
       },
       "20": {
-        "value": "1.25rem"
+        "value": "20px"
       },
       "24": {
-        "value": "1.5rem"
+        "value": "24px"
       },
       "28": {
-        "value": "1.75rem"
+        "value": "28px"
       },
       "30": {
-        "value": "1.875rem"
+        "value": "30px"
       },
       "32": {
-        "value": "2rem"
+        "value": "32px"
       },
       "38": {
-        "value": "2.375rem"
+        "value": "38px"
       },
       "42": {
-        "value": "2.625rem"
+        "value": "42px"
       }
     }
   }

--- a/packages/tokens/properties/size/spacing.json
+++ b/packages/tokens/properties/size/spacing.json
@@ -2,43 +2,43 @@
   "size": {
     "spacing": {
       "none": {
-        "value": "0rem"
+        "value": "0px"
       },
       "s": {
-        "value": "0.75rem"
+        "value": "12px"
       },
       "m": {
-        "value": "1rem"
+        "value": "16px"
       },
       "l": {
-        "value": "1.5rem"
+        "value": "24px"
       },
       "xxxs": {
-        "value": "0.125rem"
+        "value": "2px"
       },
       "xxs": {
-        "value": "0.25rem"
+        "value": "4px"
       },
       "xs": {
-        "value": "0.5rem"
+        "value": "8px"
       },
       "xm": {
-        "value": "1.125rem"
+        "value": "18px"
       },
       "xxm": {
-        "value": "1.25rem"
+        "value": "20px"
       },
       "xxxm": {
-        "value": "1.375rem"
+        "value": "22px"
       },
       "xl": {
-        "value": "2rem"
+        "value": "32px"
       },
       "xxl": {
-        "value": "3rem"
+        "value": "48px"
       },
       "xxxl": {
-        "value": "4rem"
+        "value": "64px"
       }
     }
   }


### PR DESCRIPTION
affects: @gio-design/components, @gio-design/tokens

replace rem to px

## @gio-design/components, @gio-design/tokens@20.10.6

- components,tokens
  - 将rem单位换算成px

---

## @gio-design/components, @gio-design/tokens@20.10.6

- components,tokens
  - replace rem to px
