### PR TITLE
feat(avatar): support custom tooltip title

### DIFF
--- a/packages/components/src/components/avatar/Avatar.tsx
+++ b/packages/components/src/components/avatar/Avatar.tsx
@@ -5,6 +5,7 @@ import Tooltip from '../tooltip';
 import { AvatarProps } from './interface';
 import { ConfigContext } from '../config-provider';
 import composeRef from '../../utils/composeRef';
+import { isNil } from 'lodash';
 
 const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProps, ref: React.Ref<HTMLSpanElement>) => {
   const {
@@ -17,6 +18,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
     displayTooltip = false,
     prefixCls: customizePrefixCls,
     placement = 'bottom',
+    tooltipTitle,
     ...rest
   } = props;
 
@@ -75,7 +77,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
 
   const renderTooltip = (child: React.ReactElement) =>
     displayTooltip ? (
-      <Tooltip title={userName?.trim()} placement={placement}>
+      <Tooltip title={isNil(tooltipTitle) ? userName?.trim() : tooltipTitle} placement={placement}>
         {child}
       </Tooltip>
     ) : (

--- a/packages/components/src/components/avatar/AvatarGroup.tsx
+++ b/packages/components/src/components/avatar/AvatarGroup.tsx
@@ -6,14 +6,14 @@ import { AvatarGroupProps, UserAvatarType } from './interface';
 import { ConfigContext } from '../config-provider';
 
 const AvatarGroup: React.FC<AvatarGroupProps> = (props: AvatarGroupProps) => {
-  const { number = 5, users = [], className, placement = 'bottom' } = props;
+  const { number = 5, users = [], className, placement = 'bottom', style, displayTooltip = true } = props;
   const { getPrefixCls } = useContext(ConfigContext);
   const prefixCls = getPrefixCls('avatar');
 
   let children = null;
   const renderAvatarGroup = (users: UserAvatarType[]) =>
     users.map((user, idx) => (
-      <Avatar key={idx} {...user} displayTooltip placement={placement}>
+      <Avatar key={idx} displayTooltip={displayTooltip} placement={placement} {...user}>
         {user.name}
       </Avatar>
     ));
@@ -37,6 +37,10 @@ const AvatarGroup: React.FC<AvatarGroupProps> = (props: AvatarGroupProps) => {
     );
   }
 
-  return <div className={classString}>{children}</div>;
+  return (
+    <div className={classString} style={style}>
+      {children}
+    </div>
+  );
 };
 export default AvatarGroup;

--- a/packages/components/src/components/avatar/interface.ts
+++ b/packages/components/src/components/avatar/interface.ts
@@ -19,19 +19,25 @@ export interface AvatarProps {
   omit?: boolean;
   className?: string;
   children?: string;
-  displayTooltip?: boolean;
+  style?: React.CSSProperties;
   placement?: tooltipPlacement;
   prefixCls?: string;
+  displayTooltip?: boolean;
+  tooltipTitle?: React.ReactNode;
 }
 
 export interface UserAvatarType {
   name: string;
   src?: string;
+  displayTooltip?: boolean;
+  tooltipTitle?: React.ReactNode;
 }
 
 export interface AvatarGroupProps {
   className?: string;
+  style?: React.CSSProperties;
   number?: number;
   users: UserAvatarType[];
   placement?: tooltipPlacement;
+  displayTooltip?: boolean;
 }

--- a/packages/website/src/components/functional/avatar/demo/group.tsx
+++ b/packages/website/src/components/functional/avatar/demo/group.tsx
@@ -8,6 +8,7 @@ export default () => {
     {
       name: 'li',
       src: image,
+      tooltipTitle: '这是li',
     },
     {
       name: 'pan',

--- a/packages/website/src/components/functional/avatar/index.zh-CN.md
+++ b/packages/website/src/components/functional/avatar/index.zh-CN.md
@@ -44,17 +44,22 @@ group:
 | **prefixCls**      | 自定义 css 类前缀          | `string`                              |            |
 | **displayTooltip** | 用 tooltip 显示用户名      | `boolean`                             | `false`    |
 | **className**      | 自定义混入 css 类          | `string`                              |            |
+| **style**          | 自定义混入 css 样式        | `React.CSSProperties`                 |            |
 | **children**       | 设置字符用作用户头像       | `string`                              |            |
 | **placement**      | 气泡框位置，可选 12 个方位 | `string`                              | `'bottom'` |
+| **displayTooltip** | 是否显示气泡框             | `boolean`                             | false      |
+| **tooltipTitle**   | 自定义气泡框的内容         | `React.ReactNode`                     |            |
 
 ### AvatarGroup
 
-| 参数          | 说明                                                   | 类型               | 默认值     |
-| ------------- | ------------------------------------------------------ | ------------------ | ---------- |
-| **number**    | 设置显示出来的头像个数，包含最后一项显示剩余个数的头像 | `number`           | `5`        |
-| **users**     | 用户头像数据数组                                       | `UserAvatarType[]` | `[]`       |
-| **className** | 自定义混入 css 类                                      | `string`           |            |
-| **placement** | Group 下所有头像气泡框位置, 可选 12 个方位             | `string`           | `'bottom'` |
+| 参数               | 说明                                                   | 类型                  | 默认值     |
+| ------------------ | ------------------------------------------------------ | --------------------- | ---------- |
+| **number**         | 设置显示出来的头像个数，包含最后一项显示剩余个数的头像 | `number`              | `5`        |
+| **users**          | 用户头像数据数组                                       | `UserAvatarType[]`    | `[]`       |
+| **className**      | 自定义混入 css 类                                      | `string`              |            |
+| **style**          | 自定义混入 css 样式                                    | `React.CSSProperties` |            |
+| **placement**      | Group 下所有头像气泡框位置, 可选 12 个方位             | `string`              | `'bottom'` |
+| **displayTooltip** | 是否显示气泡框                                         | `boolean`             | true       |
 
 ### Option
 
@@ -62,5 +67,7 @@ group:
 interface UserAvatarType {
   name: string;
   src?: string;
+  displayTooltip?: boolean;
+  tooltipTitle?: React.ReactNode;
 }
 ```


### PR DESCRIPTION
affects: @gio-design/components, website

ISSUES CLOSED: #418

## @gio-design/components@20.11.1

- 头像
   - 支持自定义气泡框内容
   - 添加 style 参数
---

## @gio-design/components@20.11.1

- Avatar 
  - support custom tooltip title
  - add style prop
