### PR TITLE
fix(button): change assist button background to transparent

### DIFF
--- a/packages/tokens/properties/color/background.json
+++ b/packages/tokens/properties/color/background.json
@@ -65,7 +65,7 @@
         },
         "assist": {
           "normal": {
-            "value": "{palette.white.value}"
+            "value": "transparent"
           },
           "hover": {
             "value": "{palette.gray.3.value}"


### PR DESCRIPTION
affects: @gio-design/tokens

change assist button background to transparent

## @gio-design/tokens@20.10.6

- 按钮
  - 将assist类型的按钮背景色由白色改为透明

---

## @gio-design/tokens@20.10.6

- button
  - change assist button background to transparent
