### PR TITLE
refactor(popconfirm/popover): fix the stylelint and eslint error

### DIFF
--- a/packages/components/src/components/popconfirm/__tests__/Popconfirm.test.js
+++ b/packages/components/src/components/popconfirm/__tests__/Popconfirm.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import { mount, render } from 'enzyme';
 import Popconfirm from '../index';
 import { waitForComponentToPaint } from '../../../utils/test';
-import { mount, render } from 'enzyme';
 
 describe('Testing popconfirm', () => {
   const getPopconfirm = () => (

--- a/packages/components/src/components/popconfirm/interface.ts
+++ b/packages/components/src/components/popconfirm/interface.ts
@@ -3,8 +3,8 @@ import { TooltipProps } from '../tooltip/interface';
 export interface PopconfirmProps extends Omit<TooltipProps, 'title' | 'tooltipLink'> {
   title: string;
   desc?: string;
-  onCancel?: Function;
-  onConfirm?: Function;
+  onCancel?: (e:React.MouseEvent<HTMLElement, MouseEvent>)=>void;
+  onConfirm?: (e:React.MouseEvent<HTMLElement, MouseEvent>)=>void;
   okText?: string;
   cancelText?: string;
   icon?: React.ReactNode;

--- a/packages/components/src/components/popover/__tests__/Popover.test.js
+++ b/packages/components/src/components/popover/__tests__/Popover.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import Popover from '../index';
-import '@gio-design/components/es/components/Tabs/style/index.css';
-import { waitForComponentToPaint } from '../../../utils/test';
 import { mount, render } from 'enzyme';
+import Popover from '../index';
+import '../../../../es/components/tabs/style/index.css';
+import { waitForComponentToPaint } from '../../../utils/test';
 
 describe('Testing Popover', () => {
   const getPopover = () => (


### PR DESCRIPTION
affects: @gio-design/components

fix the stylelint and eslint error

## @gio-design/components@20.10.6

- 气泡确认框、气泡卡片
  -修复eslint错误

---

## @gio-design/components@20.10.6

- popconfirm/popover
  - fix the stylelint and eslint error
