### PR TITLE
docs(release): @gio-design/components 20.11.0 change log

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/components",
-  "version": "20.11.6",
+  "version": "20.11.0",
   "description": "GrowingIO Design components",
   "author": "GrowingIO Frontend Team <eng-frontend@growingio.com>",
   "module": "./es/index.js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gio-design/components",
-  "version": "20.10.6",
+  "version": "20.11.6",
   "description": "GrowingIO Design components",
   "author": "GrowingIO Frontend Team <eng-frontend@growingio.com>",
   "module": "./es/index.js",

--- a/packages/components/src/components/select/Select.tsx
+++ b/packages/components/src/components/select/Select.tsx
@@ -259,6 +259,8 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
         }
         clearInput();
         break;
+      default:
+        break;
     }
   };
 
@@ -364,6 +366,7 @@ const Select: React.FC<SelectProps> = (props: SelectProps) => {
       {completeOptions.length > 0 ? (
         <List
           value={value}
+          width={autoWidth ? Math.max(selectorRef.current?.clientWidth || 0, 160) : undefined}
           dataSource={completeOptions}
           onChange={onValueChange}
           isMultiple={multiple}

--- a/packages/website/src/develop/changelog/components.en-US.md
+++ b/packages/website/src/develop/changelog/components.en-US.md
@@ -9,7 +9,7 @@ nav:
 
 # @gio-design/components Change Log
 
-## 20.11.6
+## 20.11.0
 
 - component
   - Select #393

--- a/packages/website/src/develop/changelog/components.en-US.md
+++ b/packages/website/src/develop/changelog/components.en-US.md
@@ -12,7 +12,7 @@ nav:
 ## 20.11.6
 
 - component
-  - Select
+  - Select #393
     - 🆕 add disabled feature
     - 🆕 add allowCustomOption prop
     - 🆕 add notFoundContent prop
@@ -30,24 +30,25 @@ nav:
     - 🛎 options must follow the options of List Interface
     - 🛎 value && defaultValue now support string or string[] as single or mulit selection mode
     - 🛎 sign of onChange method has been change form (options: Option | Option[] ) to (value: string | string[], options: Option | Option[])
-  - Dropdown
+    - 🐛 fix auto width style issue #434
+  - Dropdown #395
     - 🐛 fix onVisibleChange not be call after click
-  - List
+  - List #412
     - 🆕 support string type of width
-  - SearchBar
+  - SearchBar #408
     - 🐛 Let the display panel adapt to the width of input,and let the prompt text show '...' when the width is too short
-  - Input
+  - Input #422
     - 🆕 add prefixWidth for prefix, suffixWidth for suffix, format prefix element style
-  - Menu
+  - Menu #417
     - 🆕 mount menuitem, submenu to menu
-  - Button
+  - Button #425
     - 🆕 change assist button background to transparent
-  - Table
+  - Table #427
     - 🆕 add getCheckboxProps prop
-  - Avatar
+  - Avatar #420
     - 🆕 support custom tooltip title
     - 🆕 add style prop
-  - Form
+  - Form #419
     - 🆕 add style prop to Form and Item
 
 ## 20.10.6

--- a/packages/website/src/develop/changelog/components.en-US.md
+++ b/packages/website/src/develop/changelog/components.en-US.md
@@ -9,6 +9,47 @@ nav:
 
 # @gio-design/components Change Log
 
+## 20.11.6
+
+- component
+  - Select
+    - 🆕 add disabled feature
+    - 🆕 add allowCustomOption prop
+    - 🆕 add notFoundContent prop
+    - 🆕 add dropdownClassName && dropdownStyle prop
+    - 🆕 add borderd prop
+    - 🆕 add arrowComponent prop
+    - 🆕 add autoWidth prop
+    - 🆕 add matchPredicate method
+    - 🆕 add onSearch method
+    - 🆕 add onSelect method
+    - 🆕 add onDeSelect method
+    - 🆕 add dropDownVisible prop
+    - 🆕 add onDropdownVisibleChange method
+    - 🛎 remove width prop
+    - 🛎 options must follow the options of List Interface
+    - 🛎 value && defaultValue now support string or string[] as single or mulit selection mode
+    - 🛎 sign of onChange method has been change form (options: Option | Option[] ) to (value: string | string[], options: Option | Option[])
+  - Dropdown
+    - 🐛 fix onVisibleChange not be call after click
+  - List
+    - 🆕 support string type of width
+  - SearchBar
+    - 🐛 Let the display panel adapt to the width of input,and let the prompt text show '...' when the width is too short
+  - Input
+    - 🆕 add prefixWidth for prefix, suffixWidth for suffix, format prefix element style
+  - Menu
+    - 🆕 mount menuitem, submenu to menu
+  - Button
+    - 🆕 change assist button background to transparent
+  - Table
+    - 🆕 add getCheckboxProps prop
+  - Avatar
+    - 🆕 support custom tooltip title
+    - 🆕 add style prop
+  - Form
+    - 🆕 add style prop to Form and Item
+
 ## 20.10.6
 
 - component
@@ -35,7 +76,6 @@ nav:
   - 🆕An optional parameter successBorder is added to the upload component to control whether the border is displayed after the image is uploaded successfully. The default value is false [#331](https://github.com/growingio/gio-design/pull/331)
 - Select
   - 💄The text size in the input selection box of the select component is defined [#337](https://github.com/growingio/gio-design/pull/337)
-
 
 ## 20.10.4
 

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -12,7 +12,7 @@ nav:
 ## 20.11.6
 
 - component
-  - Select
+  - Select #393
     - 🆕 新增 disabled 禁用功能
     - 🆕 新增 allowCustomOption 可开启通过搜索输入增加 option
     - 🆕 新增 notFoundContent 可配置无搜索结果的展示内容
@@ -31,24 +31,25 @@ nav:
     - 🛎 options 现在不允许自定义格式，保持和 List option 格式一致
     - 🛎 value && defaultValue 现在可接受 string 或者 string[] 分别对应单选和多选模式
     - 🛎 onChange 方法的输入值 (options: Option | Option[] ) 改为 (value: string | string[], options: Option | Option[])
-  - Dropdown
+    - 修复 auto width 样式问题 #434
+  - Dropdown #395
     - 🐛 修复点击后 onVisibleChange 没有被调用
-  - List
+  - List #412
     - 🆕 width 支持 string 类型
-  - SearchBar
+  - SearchBar #408
     - 🐛 让展示面板自适应 input 的宽度，并且让提示文字在宽度过小时超出部分显示 ...
-  - Input
+  - Input #422
     - 🆕 给 prefix 元素默认样式，并且添加 prefixWidth 和 suffixWidth 让 input 调整左右间距
-  - Menu
+  - Menu #417
     - 🆕 挂载 menuitem, submenu 到 menu 上
-  - Button
+  - Button #425
     - 🆕 将 assist 类型的按钮背景色由白色改为透明
-  - Table
+  - Table #427
     - 🆕 添加 getCheckboxProps 参数
-  - Avatar
+  - Avatar #420
     - 🆕 支持自定义气泡框内容
     - 🆕 添加 style 参数
-  - Form
+  - Form #419
     - 🆕 给 Form 组件和 Form.Item 增加 style 属性
 
 ## 20.10.6

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -9,7 +9,7 @@ nav:
 
 # @gio-design/components 更新日志
 
-## 20.11.6
+## 20.11.0
 
 - component
   - Select #393

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -9,32 +9,74 @@ nav:
 
 # @gio-design/components 更新日志
 
+## 20.11.6
+
+- component
+  - Select
+    - 🆕 新增 disabled 禁用功能
+    - 🆕 新增 allowCustomOption 可开启通过搜索输入增加 option
+    - 🆕 新增 notFoundContent 可配置无搜索结果的展示内容
+    - 🆕 新增 dropdownClassName && dropdownStyle 可对 dropdown overlay 进行样式设置
+    - 🆕 新增 borderd 属性，可配置有无边框
+    - 🆕 新增 arrowComponent 属性，可配置箭头 icon 组件
+    - 🆕 新增 autoWidth 属性, 可配置下拉框是否自动和选择框同宽
+    - 🆕 新增 matchPredicate 方法，是否有绝对匹配的判断方法，影响在有绝对匹配下的行为，例如是否需要创建新的 option
+    - 🆕 新增 onSearch 方法，当搜索框内容变化时返回
+    - 🆕 新增 onSelect 方法，选中时回调
+    - 🆕 新增 onDeSelect 方法，取消时回调
+    - 🆕 新增 dropDownVisible 属性，控制是否展示 dropdown
+    - 🆕 新增 onDropdownVisibleChange 方法，当 dropdown visible 属性改变时回调。
+    - 🛎 width, width 现可用 classname 或 style 来控制。
+    - 🛎 siz 属性现在可以受 sizeContext 控制
+    - 🛎 options 现在不允许自定义格式，保持和 List option 格式一致
+    - 🛎 value && defaultValue 现在可接受 string 或者 string[] 分别对应单选和多选模式
+    - 🛎 onChange 方法的输入值 (options: Option | Option[] ) 改为 (value: string | string[], options: Option | Option[])
+  - Dropdown
+    - 🐛 修复点击后 onVisibleChange 没有被调用
+  - List
+    - 🆕 width 支持 string 类型
+  - SearchBar
+    - 🐛 让展示面板自适应 input 的宽度，并且让提示文字在宽度过小时超出部分显示 ...
+  - Input
+    - 🆕 给 prefix 元素默认样式，并且添加 prefixWidth 和 suffixWidth 让 input 调整左右间距
+  - Menu
+    - 🆕 挂载 menuitem, submenu 到 menu 上
+  - Button
+    - 🆕 将 assist 类型的按钮背景色由白色改为透明
+  - Table
+    - 🆕 添加 getCheckboxProps 参数
+  - Avatar
+    - 🆕 支持自定义气泡框内容
+    - 🆕 添加 style 参数
+  - Form
+    - 🆕 给 Form 组件和 Form.Item 增加 style 属性
+
 ## 20.10.6
 
 - component
-  - 🆕 avatar, card类型的 Upload 支持 placeholderImg 展示 [#379](https://github.com/growingio/gio-design/pull/379)
+  - 🆕 avatar, card 类型的 Upload 支持 placeholderImg 展示 [#379](https://github.com/growingio/gio-design/pull/379)
   - 🛎 StepModal 的 onNext, onBack 支持异步调用，可打断下一步的执行 [#378](https://github.com/growingio/gio-design/pull/378)
 - popconfirm
-  - 去掉跟disabled相关的代码 [#377](https://github.com/growingio/gio-design/pull/377)
+  - 去掉跟 disabled 相关的代码 [#377](https://github.com/growingio/gio-design/pull/377)
 - tootip
   - 🆕 新增 disabled 参数 [#367](https://github.com/growingio/gio-design/pull/367)
 - input
-  - 修改Input组件为受控组件，以及相关website demo，unit test, 样式不再固定为300px [#374](https://github.com/growingio/gio-design/pull/374)
+  - 修改 Input 组件为受控组件，以及相关 website demo，unit test, 样式不再固定为 300px [#374](https://github.com/growingio/gio-design/pull/374)
 - Table
-  - 修复当Table内容为空时，鼠标hover 会变色的问题。定义当设置ellipsis时与render方法之间的关系。[#334](https://github.com/growingio/gio-design/pull/334)
+  - 修复当 Table 内容为空时，鼠标 hover 会变色的问题。定义当设置 ellipsis 时与 render 方法之间的关系。[#334](https://github.com/growingio/gio-design/pull/334)
 
 ## 20.10.5
 
 - Grid
-  - 🆕 新增Grid组件 [#338](https://github.com/growingio/gio-design/pull/338)
+  - 🆕 新增 Grid 组件 [#338](https://github.com/growingio/gio-design/pull/338)
 - Form
-  - 🐛修复colon不渲染的问题 [#340](https://github.com/growingio/gio-design/pull/340)
+  - 🐛 修复 colon 不渲染的问题 [#340](https://github.com/growingio/gio-design/pull/340)
 - Dropdown
-  - 💄placement由12个方向改为只有上下6个方向可选，默认方向为下 [#333](https://github.com/growingio/gio-design/pull/333/)
+  - 💄placement 由 12 个方向改为只有上下 6 个方向可选，默认方向为下 [#333](https://github.com/growingio/gio-design/pull/333/)
 - Upload
-  - 🆕增加一个可选参数successBorder，控制图片上传成功后边框是否显示 [#331](https://github.com/growingio/gio-design/pull/331)
+  - 🆕 增加一个可选参数 successBorder，控制图片上传成功后边框是否显示 [#331](https://github.com/growingio/gio-design/pull/331)
 - Select
-  - 💄定义了select组件中input选择框内的文字尺寸 [#337](https://github.com/growingio/gio-design/pull/337)
+  - 💄 定义了 select 组件中 input 选择框内的文字尺寸 [#337](https://github.com/growingio/gio-design/pull/337)
 
 ## 20.10.4
 

--- a/packages/website/src/develop/changelog/components.zh-CN.md
+++ b/packages/website/src/develop/changelog/components.zh-CN.md
@@ -31,7 +31,7 @@ nav:
     - 🛎 options 现在不允许自定义格式，保持和 List option 格式一致
     - 🛎 value && defaultValue 现在可接受 string 或者 string[] 分别对应单选和多选模式
     - 🛎 onChange 方法的输入值 (options: Option | Option[] ) 改为 (value: string | string[], options: Option | Option[])
-    - 修复 auto width 样式问题 #434
+    - 🐛 修复 auto width 样式问题 #434
   - Dropdown #395
     - 🐛 修复点击后 onVisibleChange 没有被调用
   - List #412


### PR DESCRIPTION
affects: @gio-design/components, website

## @gio-design/package@20-11-0

  - Select #393 
    - 🆕 新增 disabled 禁用功能
    - 🆕 新增 allowCustomOption 可开启通过搜索输入增加 option
    - 🆕 新增 notFoundContent 可配置无搜索结果的展示内容
    - 🆕 新增 dropdownClassName && dropdownStyle 可对 dropdown overlay 进行样式设置
    - 🆕 新增 borderd 属性，可配置有无边框
    - 🆕 新增 arrowComponent 属性，可配置箭头 icon 组件
    - 🆕 新增 autoWidth 属性, 可配置下拉框是否自动和选择框同宽
    - 🆕 新增 matchPredicate 方法，是否有绝对匹配的判断方法，影响在有绝对匹配下的行为，例如是否需要创建新的 option
    - 🆕 新增 onSearch 方法，当搜索框内容变化时返回
    - 🆕 新增 onSelect 方法，选中时回调
    - 🆕 新增 onDeSelect 方法，取消时回调
    - 🆕 新增 dropDownVisible 属性，控制是否展示 dropdown
    - 🆕 新增 onDropdownVisibleChange 方法，当 dropdown visible 属性改变时回调。
    - 🛎 width, width 现可用 classname 或 style 来控制。
    - 🛎 siz 属性现在可以受 sizeContext 控制
    - 🛎 options 现在不允许自定义格式，保持和 List option 格式一致
    - 🛎 value && defaultValue 现在可接受 string 或者 string[] 分别对应单选和多选模式
    - 🛎 onChange 方法的输入值 (options: Option | Option[] ) 改为 (value: string | string[], options: Option | Option[])
    - 🐛 修复 auto width 样式问题 #434 
  - Dropdown #395 
    - 🐛 修复点击后 onVisibleChange 没有被调用
  - List #412 
    - 🆕 width 支持 string 类型
  - SearchBar #408 
    - 🐛 让展示面板自适应 input 的宽度，并且让提示文字在宽度过小时超出部分显示 ...
  - Input #422 
    - 🆕 给 prefix 元素默认样式，并且添加 prefixWidth 和 suffixWidth 让 input 调整左右间距
  - Menu #417 
    - 🆕 挂载 menuitem, submenu 到 menu 上
  - Button #425 
    - 🆕 将 assist 类型的按钮背景色由白色改为透明
  - Table #427 
    - 🆕 添加 getCheckboxProps 参数
  - Avatar #420 
    - 🆕 支持自定义气泡框内容
    - 🆕 添加 style 参数
  - Form #419 
    - 🆕 给 Form 组件和 Form.Item 增加 style 属性

---

## @gio-design/package@20-11-0

  - Select #393 
    - 🆕 add disabled feature
    - 🆕 add allowCustomOption prop
    - 🆕 add notFoundContent prop
    - 🆕 add dropdownClassName && dropdownStyle prop
    - 🆕 add borderd prop
    - 🆕 add arrowComponent prop
    - 🆕 add autoWidth prop
    - 🆕 add matchPredicate method
    - 🆕 add onSearch method
    - 🆕 add onSelect method
    - 🆕 add onDeSelect method
    - 🆕 add dropDownVisible prop
    - 🆕 add onDropdownVisibleChange method
    - 🛎 remove width prop
    - 🛎 options must follow the options of List Interface
    - 🛎 value && defaultValue now support string or string[] as single or mulit selection mode
    - 🛎 sign of onChange method has been change form (options: Option | Option[] ) to (value: string | string[], options: Option | Option[])
    - 🐛 fix auto width style issue #434 
  - Dropdown #395 
    - 🐛 fix onVisibleChange not be call after click
  - List  #412 
    - 🆕 support string type of width
  - SearchBar #408 
    - 🐛 Let the display panel adapt to the width of input,and let the prompt text show '...' when the width is too short
  - Input  #422 
    - 🆕 add prefixWidth for prefix, suffixWidth for suffix, format prefix element style
  - Menu  #417 
    - 🆕 mount menuitem, submenu to menu
  - Button #425 
    - 🆕 change assist button background to transparent
  - Table  #427 
    - 🆕 add getCheckboxProps prop
  - Avatar  #420 
    - 🆕 support custom tooltip title
    - 🆕 add style prop
  - Form #419 
    - 🆕 add style prop to Form and Item