### PR TITLE
refactor(tab-nav/tabs): fix the eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,6 @@ module.exports = {
     'import/extensions': ['off', 'never'],
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error'],
-    'no-param-reassign': ["error", { "props": false }],
+    'no-underscore-dangle': 'off',
   },
 };

--- a/packages/components/src/components/tab-nav/TabNav.tsx
+++ b/packages/components/src/components/tab-nav/TabNav.tsx
@@ -72,19 +72,20 @@ const TabNav = (props: TabNavProps, ref?: React.RefObject<HTMLDivElement>) => {
       return null;
     });
     return [_tabNavKeys, _tabNavChildren];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [children, localActiveKey, onChange, onTabClick]);
 
   useMemo(() => {
     if (!tabNavKeys.includes(localActiveKey)) {
       setLocalActiveKey(tabNavKeys[0]);
     }
-  }, []);
+  }, [localActiveKey, tabNavKeys]);
 
   useMemo(() => {
     if (!isNil(activeKey) && tabNavKeys.includes(activeKey)) {
       setLocalActiveKey(activeKey);
     }
-  }, [activeKey]);
+  }, [activeKey, tabNavKeys]);
 
   useEffect(() => {
     if (!isNil(getRef(localActiveKey)?.current) && !isNil(getRef(wrapperRefKey.current)?.current)) {
@@ -92,6 +93,7 @@ const TabNav = (props: TabNavProps, ref?: React.RefObject<HTMLDivElement>) => {
       const wrapperLeft = getRef(wrapperRefKey.current)!.current!.getBoundingClientRect().left;
       setInkStyle({ left: left - wrapperLeft, width });
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [localActiveKey, tabNavChildren]);
 
   return (
@@ -104,6 +106,7 @@ const TabNav = (props: TabNavProps, ref?: React.RefObject<HTMLDivElement>) => {
 
 TabNav.Item = React.forwardRef(
   ({ prefixCls, children, ...rest }: TabNavItemProps, ref: React.RefObject<HTMLDivElement>) => (
+    // eslint-disable-next-line react/jsx-props-no-spreading
     <div ref={ref} {...rest}>
       <div className={`${prefixCls}-item-btn`}>{children}</div>
     </div>

--- a/packages/components/src/components/tabs/Tabs.tsx
+++ b/packages/components/src/components/tabs/Tabs.tsx
@@ -56,20 +56,20 @@ const Tabs = (props: TabProps, ref: React.Ref<HTMLDivElement>) => {
       return null;
     });
     return [_tabItem, _tabPane];
-  }, [children, localActiveKey]);
+  }, [children, localActiveKey, prefixCls]);
 
   const tabNavKeys = useMemo(() => tabNav.map((item) => item.key!), [tabNav]);
   useMemo(() => {
     if (!tabNavKeys.includes(localActiveKey)) {
       setLocalActiveKey(tabNavKeys[0]);
     }
-  }, []);
+  }, [localActiveKey, tabNavKeys]);
 
   useMemo(() => {
     if (!isNil(activeKey) && tabNavKeys.includes(activeKey)) {
       setLocalActiveKey(activeKey);
     }
-  }, [activeKey]);
+  }, [activeKey, tabNavKeys]);
 
   return (
     <div className={classString} ref={ref} style={style}>

--- a/packages/components/src/components/tabs/__tests__/Tabs.test.js
+++ b/packages/components/src/components/tabs/__tests__/Tabs.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import Tabs, { TabPane } from '../index';
-import '@gio-design/components/es/components/Tabs/style/index.css';
 import { mount, render, shallow } from 'enzyme';
+import Tabs, { TabPane } from '../index';
+import '../../../../es/components/tabs/style/index.css';
 
 describe('Testing Tabs', () => {
   const getTabs = () => (


### PR DESCRIPTION
affects: @gio-design/components

fix the eslint error

## @gio-design/components@20.10.6

- 标签导航
  - 修复eslint错误
- 标签页
  - 修复eslint错误

---

## @gio-design/components@20.10.6

- tab-nav
  - fix the eslint error
- tabs
  - fix the eslint error
