### PR TITLE
style(other components): fix the stylelint and eslint error

### DIFF
--- a/packages/components/src/components/avatar/Avatar.tsx
+++ b/packages/components/src/components/avatar/Avatar.tsx
@@ -22,6 +22,8 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
     ...rest
   } = props;
 
+  const { style } = rest;
+
   const { getPrefixCls } = useContext(ConfigContext);
   const [isImgExist, setIsImgExist] = useState<boolean>(src !== undefined);
   const [scale, setScale] = useState<number>(1);
@@ -85,8 +87,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
     );
 
   return renderTooltip(
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <span ref={mergedRef} className={classString} {...rest}>
+    <span ref={mergedRef} className={classString} style={style}>
       {renderMore()}
       {renderAvatar()}
     </span>

--- a/packages/components/src/components/avatar/__tests__/Avatar.test.js
+++ b/packages/components/src/components/avatar/__tests__/Avatar.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import Avatar from '../Avatar';
-import '@gio-design/components/es/components/avatar/style/index.css';
 import renderer from 'react-test-renderer';
-import { waitForComponentToPaint } from '../../../utils/test';
 import { mount } from 'enzyme';
+import Avatar from '../Avatar';
+import '../../../../es/components/avatar/style/index.css';
+import { waitForComponentToPaint } from '../../../utils/test';
 import image from './icon.jpeg';
 
 describe('Testing Avatar', () => {

--- a/packages/components/src/components/avatar/__tests__/AvatarGroup.test.js
+++ b/packages/components/src/components/avatar/__tests__/AvatarGroup.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import AvatarGroup from '../AvatarGroup';
-import '@gio-design/components/es/components/avatar/style/index.css';
 import renderer from 'react-test-renderer';
-import { waitForComponentToPaint } from '../../../utils/test';
 import { mount } from 'enzyme';
+import AvatarGroup from '../AvatarGroup';
+import '../../../../es/components/avatar/style/index.css';
+import { waitForComponentToPaint } from '../../../utils/test';
 import image from './icon.jpeg';
 
 describe('Testing AvatarGroup', () => {

--- a/packages/components/src/components/avatar/__tests__/__snapshots__/AvatarGroup.test.js.snap
+++ b/packages/components/src/components/avatar/__tests__/__snapshots__/AvatarGroup.test.js.snap
@@ -6,7 +6,6 @@ exports[`Testing AvatarGroup should be stable 1`] = `
 >
   <span
     className="gio-avatar gio-avatar-df"
-    name="li"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -18,7 +17,6 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
-    name="pan"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -34,7 +32,6 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
-    name="leng"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -46,7 +43,6 @@ exports[`Testing AvatarGroup should be stable 1`] = `
   </span>
   <span
     className="gio-avatar gio-avatar-df"
-    name="liu"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/components/src/components/banner/Banner.tsx
+++ b/packages/components/src/components/banner/Banner.tsx
@@ -34,6 +34,7 @@ const Banner: React.FC<BannerProps> = (props: BannerProps) => {
         className={className(`${prefixCls}-closeIcon`)}
         style={{ display: closeable ? 'block' : 'none' }}
         onClick={onCloseBanner}
+        aria-hidden="true"
       >
         <Close />
       </div>

--- a/packages/components/src/components/banner/__tests__/Banner.spec.js
+++ b/packages/components/src/components/banner/__tests__/Banner.spec.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import Banner from '../Banner';
-import '@gio-design/components/es/components/banner/style/index.css';
+import '../../../../es/components/banner/style/index.css';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
+import Banner from '../Banner';
 
 describe('Testing Banner', () => {
   it('should be stable', () => {

--- a/packages/components/src/components/banner/__tests__/__snapshots__/Banner.spec.js.snap
+++ b/packages/components/src/components/banner/__tests__/__snapshots__/Banner.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Testing Banner should be stable 1`] = `
     className="gio-banner-button"
   />
   <div
+    aria-hidden="true"
     className="gio-banner-closeIcon"
     onClick={[Function]}
     style={

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import classNames from 'classnames';
 import RcCheckbox from 'rc-checkbox';
@@ -64,6 +65,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   });
 
   return (
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
     <label className={checkboxCls} style={style}>
       <CheckOutlined className={checkboxIconClass} />
       <RcCheckbox

--- a/packages/components/src/components/checkbox/group.tsx
+++ b/packages/components/src/components/checkbox/group.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react';
 import classNames from 'classnames';
 import Checkbox from './checkbox';
@@ -31,12 +32,12 @@ function CheckboxGroup<T extends CheckboxValueType>({
 }: CheckboxGroupProps<T>) {
   const registeredValuesRef = React.useRef<T[]>([]);
 
-  const registerValue = React.useCallback((value: T) => {
-    registeredValuesRef.current.push(value);
+  const registerValue = React.useCallback((values: T) => {
+    registeredValuesRef.current.push(values);
   }, []);
 
-  const unRegisterValue = React.useCallback((value: T) => {
-    registeredValuesRef.current = registeredValuesRef.current.filter((_) => _ !== value);
+  const unRegisterValue = React.useCallback((values: T) => {
+    registeredValuesRef.current = registeredValuesRef.current.filter((_) => _ !== values);
   }, []);
 
   // self maintained state
@@ -53,8 +54,8 @@ function CheckboxGroup<T extends CheckboxValueType>({
     (option: CheckboxOptionType<T>) => {
       if (value === undefined) {
         // self maintained state
-        updateSelected((selected) => {
-          const newSelected = merge(selected, option, registeredValuesRef.current);
+        updateSelected((selecting) => {
+          const newSelected = merge(selecting, option, registeredValuesRef.current);
           onChange?.(newSelected);
           return newSelected;
         });

--- a/packages/components/src/components/drawer/index.tsx
+++ b/packages/components/src/components/drawer/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import RcDrawer from 'rc-drawer';
 import { omit } from 'lodash';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
 import { Close } from '@gio-design/icons';
@@ -72,13 +73,16 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
     level: null,
   };
 
-  public readonly state = {
-    push: false,
-  };
-
   private parentDrawer: Drawer | null;
 
   private destroyClose: boolean;
+
+  public constructor(props : DrawerProps & ConfigConsumerProps){
+    super(props);
+    this.state = {
+      push: false,
+    };
+  }
 
   public componentDidMount() {
     // fix: delete drawer in child and re-render, no push started.
@@ -108,34 +112,22 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
     }
   }
 
-  public render() {
-    return <DrawerContext.Consumer>{this.renderProvider}</DrawerContext.Consumer>;
-  }
-
-  private push = () => {
-    if (this.props.push) {
-      this.setState({ push: true });
-    }
-  };
-
-  private pull = () => {
-    if (this.props.push) {
-      this.setState({ push: false });
-    }
-  };
-
   private onDestroyTransitionEnd = () => {
+    const { visible } = this.props;
     const isDestroyOnClose = this.getDestroyOnClose();
     if (!isDestroyOnClose) {
       return;
     }
-    if (!this.props.visible) {
+    if (!visible) {
       this.destroyClose = true;
       this.forceUpdate();
     }
   };
 
-  private getDestroyOnClose = () => this.props.destroyOnClose && !this.props.visible;
+  private getDestroyOnClose = () => {
+    const { destroyOnClose, visible } = this.props;
+    return destroyOnClose && !visible;
+  }
 
   private getPushDistance = () => {
     const { push } = this.props;
@@ -177,6 +169,20 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
     }
     return offsetStyle;
   }
+
+  private pull = () => {
+    const { push } = this.props;
+    if (push) {
+      this.setState({ push: false });
+    }
+  };
+
+  private push = () => {
+    const { push } = this.props;
+    if (push) {
+      this.setState({ push: true });
+    }
+  };
 
   private getRcDrawerStyle = () => {
     const {
@@ -250,7 +256,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
   // render drawer body dom
   private renderBody = () => {
     const {
-      bodyStyle, drawerStyle, prefixCls, visible,
+      bodyStyle, drawerStyle, prefixCls, visible, children
     } = this.props;
     if (this.destroyClose && !visible) {
       return null;
@@ -278,7 +284,7 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
       >
         {this.renderHeader()}
         <div className={`${prefixCls}-body`} style={bodyStyle}>
-          {this.props.children}
+          {children}
         </div>
         {this.renderFooter()}
       </div>
@@ -356,6 +362,10 @@ class Drawer extends React.Component<DrawerProps & ConfigConsumerProps, IDrawerS
       </ConfigConsumer>
     );
   };
+
+  public render() {
+    return <DrawerContext.Consumer>{this.renderProvider}</DrawerContext.Consumer>;
+  }
 }
 
 export default withConfigConsumer<DrawerProps>({

--- a/packages/components/src/components/dropdown/__test__/Dropdown.test.js
+++ b/packages/components/src/components/dropdown/__test__/Dropdown.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
+import { mount, render } from 'enzyme';
 import Dropdown from '../index';
 import Button from '../../button';
 import { waitForComponentToPaint } from '../../../utils/test';
-import { mount, render } from 'enzyme';
 
 describe('Testing dropdown', () => {
   const getDropdown = () => (

--- a/packages/components/src/components/dropdown/index.tsx
+++ b/packages/components/src/components/dropdown/index.tsx
@@ -1,3 +1,4 @@
 import Dropdown from './Dropdown';
+
 export { DropdownProps } from './interface';
 export default Dropdown;

--- a/packages/components/src/components/input/Input.tsx
+++ b/packages/components/src/components/input/Input.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import classNames from 'classnames';
 import { InputProps, InputNumberProps, TextAreaProps } from './interfaces';
 import { SizeContext } from '../config-provider/SizeContext';
+
 export const prefixCls = 'gio-input';
 const InputFC: React.FC<InputProps> = (props: InputProps) => {
   const sizeContext = useContext(SizeContext);
@@ -74,9 +75,9 @@ const InputFC: React.FC<InputProps> = (props: InputProps) => {
   if (wrapStyle !== undefined || inputStyle !== undefined) {
     console.warn(
       'The latest version of Input only accept "style" for inline-style setting, ' +
-        'please fix your code because the deprecated parameter "wrapStyle" and "inputStyle" ' +
-        'will be removed in the future version'
-    );
+      'please fix your code because the deprecated parameter "wrapStyle" and "inputStyle" ' +
+      'will be removed in the future version'
+    )
   }
 
   if (typeof prefixWidth === 'number') {

--- a/packages/components/src/components/input/TextArea.tsx
+++ b/packages/components/src/components/input/TextArea.tsx
@@ -56,6 +56,7 @@ const TextArea: React.FC<TextAreaProps> = ({
         placeholder={placeholder}
         style={innerStyle}
         ref={forwardRef}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}
       />
     </div>

--- a/packages/components/src/components/input/__tests__/input.test.js
+++ b/packages/components/src/components/input/__tests__/input.test.js
@@ -34,7 +34,7 @@ describe('Input', () => {
   it('should run onChange when input accept change event', () => {
     let val = '';
     const wrapper = mount(
-      <Input onChange={(e) => (val = e.target.value)} onPressEnter={(e) => (val = 'press enter')} />
+      <Input onChange={e => {val = e.target.value}} onPressEnter={() => {val = 'press enter'}} />
     );
     expect(wrapper.render()).toMatchSnapshot();
     wrapper.find('input').simulate('change', { target: { value: '123' } });
@@ -72,7 +72,7 @@ describe('Input.Password', () => {
 
 describe('Input.InputNumber', () => {
   it('should change type when click', () => {
-    const wrapper = mount(<Input.InputNumber onChange={() => {}} />);
+    const wrapper = mount(<Input.InputNumber onChange={() => {/* ... */}} />);
     expect(wrapper.render()).toMatchSnapshot();
     wrapper.find('input').simulate('change', { target: { value: 1 } });
     expect(wrapper.render()).toMatchSnapshot();
@@ -84,7 +84,7 @@ describe('Input.InputNumber', () => {
 
   it('should not change if the value is not between min and max, or the value is not a number', () => {
     let val = '';
-    const wrapper = mount(<Input.InputNumber max={5} min={1} onChange={(n) => (val = n)} />);
+    const wrapper = mount(<Input.InputNumber max={5} min={1} onChange={n => {val = n}} />);
     expect(wrapper.render()).toMatchSnapshot();
     wrapper.find('input').simulate('change', { target: { value: '5' } });
     expect(wrapper.render()).toMatchSnapshot();
@@ -116,7 +116,7 @@ describe('Input.TextArea', () => {
 
   it('should trigger onChange when input event happens', () => {
     let val = '';
-    const wrapper = mount(<Input.TextArea onChange={e => (val = e.target.value)} />);
+    const wrapper = mount(<Input.TextArea onChange={e => {val = e.target.value}} />);
     expect(wrapper.render()).toMatchSnapshot();
     wrapper.find('textarea').simulate('change', { target: { value: '123' }});
     expect(wrapper.render()).toMatchSnapshot();
@@ -124,12 +124,12 @@ describe('Input.TextArea', () => {
   });
 
   it('should change the height when input many characters in the textarea', () => {
-    let val = '';
+    const val = '';
     const wrapper = mount(<Input.TextArea value={val} autosize />);
     expect(wrapper.render()).toMatchSnapshot();
     wrapper.setProps({ value: 'abc'.repeat(100) })
     expect(wrapper.render()).toMatchSnapshot();
     expect(wrapper.find('textarea').prop('value')).toBe('abc'.repeat(100));
-    act(() => {});
+    act(() => {/* ... */});
   });
 });

--- a/packages/components/src/components/select/__tests__/Select.test.js
+++ b/packages/components/src/components/select/__tests__/Select.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import Select from '../index';
-import '@gio-design/components/es/components/Select/style/index.css';
+import '../../../../es/components/select/style/index.css';
 import renderer from 'react-test-renderer';
 import { shallow, mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
+import Select from '../index';
 import { CustomOption, defaultLabelRenderer } from '../Select';
 
 const labels = ['全部', '已上线', '待上线', '已下线', '草稿'];
@@ -295,7 +295,9 @@ describe('<Select /> deselect list', () => {
 
 describe('<Select /> deselect list', () => {
   it('should be able to create by enter', () => {
-    const tree = mount(<Select searchable options={optionsWithOutGroup} defaultValue="all" onDeselect={onDeSelect} />);
+    const tree = mount(
+      <Select searchable options={optionsWithOutGroup} defaultValue="all" onDeselect={onDeSelect} />
+    );
 
     const onDeSelect = (v, o) => {
       expect(v).toBe('all');

--- a/packages/components/src/components/tree-select/__tests__/tree-select.test.js
+++ b/packages/components/src/components/tree-select/__tests__/tree-select.test.js
@@ -86,7 +86,7 @@ describe('Testing tree select', () => {
     const wrapper = mount(
       <TreeSelect
         treeData={treeData}
-        treeCheckable={true}
+        treeCheckable
       />,
     );
 


### PR DESCRIPTION
affects: @gio-design/components

fix other components stylelint and eslint error

## @gio-design/components@20.10.6

- 警告提示
  - 修复stylelint和eslint错误
- 头像
  - 修复stylelint和eslint错误
- 横幅
  - 修复stylelint和eslint错误
- 单选框
  - 修复stylelint和eslint错误
- 抽屉
  - 修复stylelint和eslint错误
- 下拉菜单
  - 修复stylelint和eslint错误
- 输入框
  - 修复stylelint和eslint错误
- 选择器
  - 修复stylelint和eslint错误
- 树形选择器
  - 修复stylelint和eslint错误

---

## @gio-design/components@20.10.6

- alert
  - fix stylelint and eslint error
- avatar
  - fix stylelint and eslint error
- banner
  - fix stylelint and eslint error
- checkbox
  - fix stylelint and eslint error
- drawer
  - fix stylelint and eslint error
- dropdown
  - fix stylelint and eslint error
- input
  - fix stylelint and eslint error
- select
  - fix stylelint and eslint error
- tree-select
  - fix stylelint and eslint error
