### PR TITLE
fix(dropdown): define dropdown interaction

### DIFF
--- a/packages/components/src/components/dropdown/Dropdown.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, cloneElement } from 'react';
-import { isFunction } from 'lodash';
+import { isFunction, isUndefined } from 'lodash';
 import Tooltip from '../tooltip';
 import { DropdownProps } from './interface';
 import { ConfigContext } from '../config-provider';
@@ -28,7 +28,7 @@ const Dropdown = (props: DropdownProps) => {
       onVisibleChange?.(false);
       _overlay.props.onClick?.(e);
     };
-    return cloneElement(_overlay, { onClick: onOverlayClick });
+    return isUndefined(visible) ? cloneElement(_overlay, { onClick: onOverlayClick }) : _overlay;
   };
 
   return (

--- a/packages/components/src/components/dropdown/__test__/Dropdown.test.js
+++ b/packages/components/src/components/dropdown/__test__/Dropdown.test.js
@@ -26,23 +26,29 @@ describe('Testing dropdown', () => {
     }).not.toThrow();
   });
 
-  it('should be render rightly', (done) => {
+  it('should be render rightly', async () => {
     const wrapper = mount(getDropdown());
     wrapper.setProps({ trigger: 'click' });
     wrapper.setProps({ placement: 'topLeft' });
     wrapper.find('button').at(0).simulate('click');
     expect(wrapper.exists('.gio-dropdown-inner')).toBe(true);
-    waitForComponentToPaint(wrapper).then(() => {
-      expect(wrapper.exists('.gio-dropdown-placement-topLeft')).toBe(true);
-      done();
-    });
+    await waitForComponentToPaint(wrapper);
+    expect(wrapper.exists('.gio-dropdown-placement-topLeft')).toBe(true);
   });
 
-  it('will be close after click', () => {
+  it('will be close after click without visible', () => {
     const wrapper = mount(getDropdown());
     wrapper.setProps({ destroyTooltipOnHide: true });
     wrapper.find('button').at(0).simulate('click');
     wrapper.find('#overlay-content').simulate('click');
     expect(wrapper.exists('.gio-dropdown-inner')).toBe(false);
+  });
+
+  it('will not be close after click with visible', async () => {
+    const wrapper = mount(getDropdown());
+    wrapper.setProps({ destroyTooltipOnHide: true, visible: true });
+    await waitForComponentToPaint(wrapper);
+    wrapper.find('#overlay-content').simulate('click');
+    expect(wrapper.exists('.gio-dropdown-inner')).toBe(true);
   });
 });


### PR DESCRIPTION
affects: @gio-design/components

## @gio-design/components@20.11.1

- 下拉框
  - 定义交互逻辑，当未传visible参数点击overlay区域会关闭下拉框。

---

## @gio-design/components@20.11.1

- Dropdown
  - define dropdown interaction, it will be close after click the overlay area without visible.
