### PR TITLE
fix(button): fix parent node mouseleave not work when button disabled

### DIFF
--- a/packages/components/src/components/button/style/mixin.less
+++ b/packages/components/src/components/button/style/mixin.less
@@ -141,6 +141,7 @@
   }
   &[disabled] {
     cursor: not-allowed;
+    pointer-events: none;
     > * {
       pointer-events: none;
     }


### PR DESCRIPTION
affects: @gio-design/components

## @gio-design/components@20.11.1

- 按钮
  - 修复父节点 mouseleave 事件无法被触发 当按钮是disabled的时候。

---

## @gio-design/components@20.11.1

- Button
  - fix parent node mouseleave not work when button disabled
