### PR TITLE
fix(table, checkbox): fix onRow-click be call when click table selection

### DIFF
--- a/packages/components/src/components/checkbox/interface.tsx
+++ b/packages/components/src/components/checkbox/interface.tsx
@@ -43,7 +43,7 @@ export interface CheckboxProps {
    */
   disabled?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
-
+  onClick?: React.MouseEventHandler<HTMLElement>;
   value?: any;
   children?: React.ReactNode;
   id?: string;

--- a/packages/components/src/components/checkbox/style/index.less
+++ b/packages/components/src/components/checkbox/style/index.less
@@ -45,7 +45,7 @@
   z-index: 999;
   transform: scale(0);
   transition: all 0.5s;
-
+  pointer-events: none;
   svg {
     width: 10px;
     height: 10px;
@@ -72,8 +72,10 @@
   position: relative;
 
   &-input {
-    display: none;
-    margin-right: 8px;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    opacity: 0;
   }
 
   display: inline-block;
@@ -99,6 +101,7 @@
     border-collapse: separate;
     transform: scale(0.5);
     transition: all 0.9s;
+    pointer-events: none;
 
     /**
      * 部分选中的横线

--- a/packages/components/src/components/table/hook/useSelection.tsx
+++ b/packages/components/src/components/table/hook/useSelection.tsx
@@ -67,6 +67,7 @@ const useSelection = <RecordType,>(
       <Checkbox
         checked={atLeastOneChecked}
         indeterminate={isPartChecked}
+        onClick={(e) => e.stopPropagation()}
         onChange={(e) => {
           const latestLocalSelectedRowKeys = e.target.checked
             ? difference(union(localSelectedRowKeys, currentPageRowKeys), disabledRowKey)
@@ -86,7 +87,9 @@ const useSelection = <RecordType,>(
       const thisCheckboxProps = getCheckboxProps?.(rest[1]) || {};
       return (
         <Checkbox
+          {...thisCheckboxProps}
           checked={localSelectedRowKeys.includes(key)}
+          onClick={(e) => e.stopPropagation()}
           onChange={(e) => {
             const latestLocalSelectedRowKeys = e.target.checked
               ? union(localSelectedRowKeys, [key])
@@ -94,7 +97,6 @@ const useSelection = <RecordType,>(
             setLocalSelectedRowKeys(latestLocalSelectedRowKeys);
             onChange?.(latestLocalSelectedRowKeys, getSelectRows(latestLocalSelectedRowKeys));
           }}
-          {...thisCheckboxProps}
         />
       );
     },

--- a/packages/website/src/components/functional/table/demo/pagination.tsx
+++ b/packages/website/src/components/functional/table/demo/pagination.tsx
@@ -37,7 +37,15 @@ export default () => (
     dataSource={dataSource}
     columns={columns}
     rowKey={(record) => record.a.toString()}
+    onRow={(record) => ({
+      onClick: () => {
+        // Click Checkbox will not be called
+        // eslint-disable-next-line no-console
+        console.log('on row click');
+      },
+    })}
     onChange={(p, s, f) => {
+      // eslint-disable-next-line no-console
       console.log(p, s, f);
     }}
     showIndex


### PR DESCRIPTION
affects: @gio-design/components, website

## @gio-design/package@version

- 列表
  - 选择点击设置停止冒泡
- 多选框
  - 添加 onClick 参数, 将input hidden 变成透明，其他元素禁止事件

---

## @gio-design/package@version

- Table
  - selection onClick stopPropagation
- CheckBox
  - add onclick prop, update input hidden to transparent，other domelement pointer-events: none
