### PR TITLE
docs: add stories to some Functional components

### DIFF
--- a/packages/components/src/components/banner/Banner.stories.tsx
+++ b/packages/components/src/components/banner/Banner.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import Button from '../button';
+import Banner, { BannerProps } from './index';
+import './style'
+
+export default {
+    title: 'Components/Functional/Banner',
+    component: Banner,
+} as Meta;
+
+const normalContent = (
+  <div className="alert-close">
+    【GrowingIO在线公共课】欧治云商运营负责人复盘B2B增长实践
+    <Button type="secondary" size="small" style={{ margin: '0 0 0 8px' }}>
+      立即报名
+    </Button>
+  </div>
+);
+
+const Template : Story<BannerProps> = (args) => <Banner {...args} />;
+export const Default = Template.bind({});
+Default.args = {
+    content: normalContent,
+    type: 'normal',
+    closeable: true,
+}

--- a/packages/components/src/components/banner/interface.ts
+++ b/packages/components/src/components/banner/interface.ts
@@ -1,10 +1,28 @@
 import { ReactNode } from 'react';
 
 export interface BannerProps {
+  /**
+   横幅的类型
+   */
   type?: 'normal' | 'alert';
+  /**
+   横幅内的内容
+   */
   content?: string | ReactNode;
+  /**
+   是否可以关闭
+   */
   closeable?: boolean;
+  /**
+   点击关闭横幅的回掉函数
+   */
   onClose?: () => void;
+  /**
+   横幅内自定义 `button`
+   */
   button?: ReactNode;
+  /**
+   自定义 `css` 类前缀
+   */
   prefixCls?: string;
 }

--- a/packages/components/src/components/date-picker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.stories.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import moment, { Moment } from 'moment';
+import DatePicker, { DateRangePicker, DatePickerProps, DateRangePickerProps } from './index'
+import './style'
+
+export default {
+    title: 'Components/Functional/DatePicker',
+    component: DatePicker,
+    subcomponents: { DateRangePicker },
+} as Meta;
+
+const DatePickerDemo = (args : DatePickerProps) => {
+    const [time, setTime] = useState(moment(new Date()));
+    const onChange = (value: Moment | null) => {
+      value && setTime(value);
+    };
+    const onSelect = (value: Moment) => {
+      setTime(value);
+    };
+    const disabledDate = (value: Moment) => {
+      const date = moment(new Date()).add(-1, 'days')
+      return value.isBefore(date);
+    };
+    const format = 'YYYY/MM/DD';
+    return (
+      <div style={{marginLeft:"200px",marginTop:"100px"}}>
+        <DatePicker
+          {...args}
+          value={args.value ? args.value : time}
+          onChange={args.onChange ? args.onChange : onChange}
+          onSelect={args.onSelect ? args.onSelect : onSelect}
+          format={args.format ? args.format : format}
+          showFooter={args.showFooter ? args.showFooter : true}
+          disabledDate={args.disabledDate ? args.disabledDate : disabledDate}
+        />
+      </div>
+    );
+  };
+
+const Template : Story<DatePickerProps> = (args) => <>{DatePickerDemo(args)}</>;
+export const Default = Template.bind({});
+Default.args = {
+    format: 'YYYY-MM-DD',
+}
+
+
+function disabledDates(current:Moment) {
+    return current && current < moment().endOf('day');
+}
+const RangePickerDemo = (args : DateRangePickerProps) => {
+    const [time, setTime] = useState([moment(new Date()), moment(new Date())]);
+    const format = 'YYYY/MM/DD';
+    const onChange = (value: Array<Moment> | null) => {
+      value && setTime(value);
+    };
+    const onSelect = (value: Array<Moment>) => {
+      setTime(value);
+    };
+    const renderExtraFooter = () => {
+      return <div>extra footer</div>
+    }
+    return (
+      <div style={{marginLeft:"200px",marginTop:"100px"}}>
+        <DateRangePicker 
+          renderExtraFooter={args.renderExtraFooter ? args.renderExtraFooter : renderExtraFooter} 
+          value={args.value ? args.value : time}
+          onChange={args.onChange ? args.onChange : onChange}
+          onSelect={args.onSelect ? args.onSelect : onSelect}
+          format={args.format ? args.format : format}
+          showFooter={args.showFooter ? args.showFooter : true}
+          disabledDate={args.disabledDate ? args.disabledDate : disabledDates}
+        />
+      </div>
+    );
+};
+
+const RangeTemplate : Story<DateRangePickerProps> = (args) => <>{RangePickerDemo(args)}</>;
+export const DateRangePickers = RangeTemplate.bind({});
+DateRangePickers.args = {
+    format: 'YYYY-MM-DD',
+}

--- a/packages/components/src/components/date-picker/interface.tsx
+++ b/packages/components/src/components/date-picker/interface.tsx
@@ -1,28 +1,88 @@
 import { Moment } from 'moment';
 
 export interface DatePickerProps {
+  /**
+   自定义 `className`
+   */
   className?: string;
+  /**
+   自定义样式
+   */
   style?: React.CSSProperties;
+  /**
+   自定义 `css` 类前缀
+   */
   prefixCls?: string;
+  /**
+   日期显示格式
+   */
   format?: string;
+  /**
+   此受控组件绑定的时间
+   */
   value: Moment;
+  /**
+   默认显示的时间
+   */
   defaultValue?: Moment;
+  /**
+   面板切换的回调
+   */
   onChange: (v: Moment | null) => void;
+  /**
+   	选择日期的回调
+   */
   onSelect: (v: Moment) => void;
+  /**
+   是否显示footer
+   */
   showFooter: boolean;
+  /**
+   禁止选择的时间
+   */
   disabledDate?: (current: Moment) => boolean;
 }
 
 export interface DateRangePickerProps {
+  /**
+   自定义 `className`
+   */
   className?: string;
+  /**
+   是否显示footer
+   */
   showFooter?: boolean;
+  /**
+   自定义样式
+   */
   style?: React.CSSProperties;
+  /**
+   自定义 `css` 类前缀
+   */
   prefixCls?: string;
+  /**
+   日期显示格式
+   */
   format?: string;
+  /**
+   	此受控组件绑定的时间
+   */
   value: Array<Moment>;
+  /**
+   面板切换的回调
+   */
   onChange: (v: Array<Moment> | null) => void;
+  /**
+   	选择日期的回调
+   */
   onSelect: (v: Array<Moment>) => void;
+  /**
+   默认显示的时间
+   */
   defaultValue?: Array<Moment>;
   renderExtraFooter?: () => React.ReactNode;
+  /**
+   禁止选择的时间
+   */
   disabledDate?: (current: Moment) => boolean;
 }

--- a/packages/components/src/components/date-picker/style/index.less
+++ b/packages/components/src/components/date-picker/style/index.less
@@ -54,6 +54,7 @@
 .@{date-picker-prefix-cls} {
   position: relative;
   top: 45px;
+  box-sizing: border-box;
   width: 280px;
   font-size: 14px;
   line-height: 1.5;

--- a/packages/components/src/components/dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/components/dropdown/Dropdown.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Dropdown, { DropdownProps } from './index'
+import './style'
+import { Button } from '../..';
+
+export default {
+    title: 'Components/Functional/Dropdown',
+    component: Dropdown,
+} as Meta;
+
+const overlay = (
+  <div
+    style={{
+    width: 120,
+    height: 120,
+    border: '1px dashed #DCDFED',
+    borderRadius: '4px',
+    backgroundColor: '#FFFFFF',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }}
+  >
+    内容区域
+  </div>
+)
+
+const Template : Story<DropdownProps> = (args) => (
+  <Dropdown {...args}>
+    <Button>点击下拉</Button>
+  </Dropdown>
+)
+export const Default = Template.bind({});
+Default.args = {
+    overlay,
+}

--- a/packages/components/src/components/dropdown/interface.ts
+++ b/packages/components/src/components/dropdown/interface.ts
@@ -1,5 +1,8 @@
 import { TooltipProps } from '../tooltip/interface';
 
 export interface DropdownProps extends Omit<TooltipProps, 'title' | 'tooltipLink' | 'arrowPointAtCenter' | 'overlay'> {
+  /**
+   下拉区域
+   */
   overlay: (() => React.ReactElement) | React.ReactElement;
 }

--- a/packages/components/src/components/form/Form.stories.tsx
+++ b/packages/components/src/components/form/Form.stories.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import Form, { useForm } from './index'
+import Item from './Item'
+import { Props, FormItemProps } from './interface'
+import './style'
+import '../input/style'
+import '../button/style'
+import './style/demo.less'
+import { Button, Input, Modal } from '../..';
+
+
+export default {
+    title: 'Components/Functional/Form',
+    component: Form,
+    subcomponents: { Item },
+} as unknown as Meta;
+
+const FormStory = (args: Props): JSX.Element => {
+    const [form] = useForm();
+    const onReset = () => {
+      form.resetFields();
+    };
+    return (
+      <Form {...args}>
+        <Item
+          name="username"
+          label="用户名"
+          required
+          rules={[{ required: true, message: 'Please input your username!' }]}
+        >
+          <Input placeholder="请输入用户名" />
+        </Item>
+        <Item name="password" label="密码" required rules={[{ required: true, message: 'Please input your password!' }]}>
+          <Input.Password placeholder="请输入密码" />
+        </Item>
+        <Item>
+          <div>
+            <Button htmlType="reset" type="secondary" onClick={onReset}>
+              重置
+            </Button>
+            <Button htmlType="submit">提交</Button>
+          </div>
+        </Item>
+      </Form>
+    );
+}
+
+// Form Story
+const Template : Story<Props> = (args) => <>{FormStory(args)}</>
+export const Default = Template.bind({});
+Default.args = {
+    name: 'base',
+}
+
+// Form.Item Story
+const TemplateItem : Story<FormItemProps> = (args) => (
+  <Item {...args}>
+    <Input placeholder="我是一个Item" />
+  </Item>
+)
+export const FormItems = TemplateItem.bind({});
+FormItems.args = {
+  label: "用户名:",
+  name: 'ok',
+}
+
+// Form with Modal Story
+export const FormWithModal : Story<Props> = (args : Props) => {
+  const [visible, setVisible] = useState(false);
+  const [form] = useForm();
+  return (
+    <div>
+      <Button onClick={() => setVisible(true)}>click me</Button>
+      <Modal
+        visible={visible}
+        title="新建账号"
+        onOk={() => {
+          setVisible(false);
+        }}
+        onClose={() => {
+          setVisible(false);
+        }}
+        afterClose={() => {
+          form.resetFields();
+        }}
+        style={{ width: 380 }}
+      >
+        <Form {...args} name="modal" form={form} labelWidth={60} layout="vertical">
+          <Item label="用户名" name="username">
+            <Input />
+          </Item>
+          <Item label="密码" name="password">
+            <Input.Password type="password" />
+          </Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};
+
+// Multiple Column Form Story
+const items = [...new Array(6)];
+export const MultipleForm : Story<Props> = (args) => {
+  return (
+    <Form {...args}>
+      {items.map((_, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Item key={i} label={`label-${i}`} name={`inline-${i}`}>
+          <Input />
+        </Item>
+      ))}
+    </Form>
+  );
+};

--- a/packages/components/src/components/form/Form.tsx
+++ b/packages/components/src/components/form/Form.tsx
@@ -1,28 +1,10 @@
-import { FormProps as RcFormProps } from 'rc-field-form/lib/Form';
 import RcForm, { FormInstance, useForm } from 'rc-field-form';
 import * as React from 'react';
 import classNames from 'classnames';
-
+import { Props } from './interface'
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
-import { FormContext, FormLabelAlign, RequiredMark } from './context';
-import { SizeContextProvider, SizeType } from '../config-provider/SizeContext';
-
-export type FormLayout = 'horizontal' | 'vertical' | 'inline';
-
-export interface Props<Values = unknown> extends Omit<RcFormProps<Values>, 'form'> {
-  prefixCls?: string;
-  className?: string;
-  name?: string;
-  labelWidth?: number;
-  inputWidth?: number;
-  labelAlign?: FormLabelAlign;
-  form?: FormInstance<Values>;
-  layout?: FormLayout;
-  size?: SizeType;
-  colon?: boolean;
-  requiredMark?: RequiredMark;
-  style?: React.CSSProperties;
-}
+import { FormContext } from './context';
+import { SizeContextProvider } from '../config-provider/SizeContext';
 
 const Form: React.ForwardRefRenderFunction<FormInstance, Props> = (props: Props, ref) => {
   const {

--- a/packages/components/src/components/form/Item.tsx
+++ b/packages/components/src/components/form/Item.tsx
@@ -1,43 +1,16 @@
-import { Field, FormInstance } from 'rc-field-form';
-import { FieldProps } from 'rc-field-form/lib/Field';
+import { Field } from 'rc-field-form';
 import { Meta } from 'rc-field-form/lib/interface';
 import FieldContext from 'rc-field-form/lib/FieldContext';
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-
+import { FormItemProps } from './interface'
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
-import { FormContext, FormLabelAlign } from './context';
+import { FormContext } from './context';
 import { hasValidName, toArray } from './util';
-import ItemControl, { FormItemFeedbackType } from './ItemControl';
+import ItemControl from './ItemControl';
 import ItemLabel from './ItemLabel';
 
-type RenderChildren = (form: FormInstance) => React.ReactNode;
-type ChildrenType = RenderChildren | React.ReactNode;
-
-export interface Props extends Omit<FieldProps, 'children'> {
-  prefixCls?: string;
-  className?: string;
-  style?: React.CSSProperties;
-  label?: string;
-  afterLabel?: React.ReactNode;
-  afterInput?: React.ReactNode;
-  children?: ChildrenType;
-  help?: React.ReactNode;
-  feedback?: React.ReactNode;
-  feedbackType?: FormItemFeedbackType;
-  required?: boolean;
-  marker?: React.ReactNode;
-  feedbackIcon?: React.ReactNode;
-  htmlFor?: string;
-  labelWidth?: number;
-  inputWidth?: number;
-  colon?: boolean;
-  labelAlign?: FormLabelAlign;
-
-  fieldKey?: React.Key | React.Key[];
-}
-
-const Item: React.FC<Props> = (props: Props) => {
+const Item: React.FC<FormItemProps> = (props: FormItemProps) => {
   const {
     requiredMark,
     name: formName,

--- a/packages/components/src/components/form/context.tsx
+++ b/packages/components/src/components/form/context.tsx
@@ -3,28 +3,16 @@ import { omit } from 'lodash';
 import { FormProviderProps as RcFormProviderProps } from 'rc-field-form/lib/FormContext';
 import React from 'react';
 
-import { FormLayout } from './Form';
+import { FormContextProps } from './interface';
 
 export type FormLabelAlign = 'left' | 'right';
 
 export type RequiredMark = boolean | 'optional';
 
-export interface FormContextProps {
-  name?: string;
-  layout?: FormLayout;
-  labelAlign?: FormLabelAlign;
-  labelWidth?: number;
-  inputWidth?: number;
-  requiredMark?: RequiredMark;
-  colon?: boolean;
-}
-
 export const FormContext = React.createContext<FormContextProps>({
   labelAlign: 'left',
   layout: 'vertical',
 });
-
-// FormContext.displayName = 'FormContext';
 
 export type FormProviderProps = Omit<RcFormProviderProps, 'validateMessages'>;
 

--- a/packages/components/src/components/form/index.tsx
+++ b/packages/components/src/components/form/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { FormItemFeedbackType } from './ItemControl';
-import Form, { Props as FormProps, FormLayout, FormInstance, List, useForm, FormProvider } from './Form';
+import Form, { FormInstance, List, useForm, FormProvider } from './Form';
+import { Props as FormProps, FormLayout, } from './interface'
 import Item from './Item';
 
 const InternalForm = React.forwardRef<FormInstance, FormProps>(Form);

--- a/packages/components/src/components/form/interface.ts
+++ b/packages/components/src/components/form/interface.ts
@@ -1,0 +1,136 @@
+import { FormProps as RcFormProps } from 'rc-field-form/lib/Form';
+import { FormInstance } from 'rc-field-form';
+import { FieldProps } from 'rc-field-form/lib/Field';
+import { FormLabelAlign, RequiredMark } from './context';
+import { SizeType } from '../config-provider/SizeContext';
+import { FormItemFeedbackType } from './ItemControl';
+
+export type FormLayout = 'horizontal' | 'vertical' | 'inline';
+
+export interface Props<Values = unknown> extends Omit<RcFormProps<Values>, 'form'> {
+  /**
+   自定义 `css` 类前缀
+   */
+  prefixCls?: string;
+  /**
+   自定义 `className`
+   */
+  className?: string;
+  /**
+   	表单名称
+   */
+  name?: string;
+  /**
+   `label` 标签的宽度（width）
+   */
+  labelWidth?: number;
+  /**
+   `input` 控制项标签的宽度（width）
+   */
+  inputWidth?: number;
+  /**
+   `label` 标签的文本对齐方式
+   */
+  labelAlign?: FormLabelAlign;
+  form?: FormInstance<Values>;
+  /**
+   表单布局
+   */
+  layout?: FormLayout;
+  /**
+   设置字段组件的尺寸（仅限 giod 组件）
+   */
+  size?: SizeType;
+  /**
+   配置 Form.Item 的 colon 的默认值。表示是否显示 label 后面的冒号 (只有在属性 layout 为 horizontal 时有效)
+   */
+  colon?: boolean;
+  /**
+   必选样式，可以切换为必选或者可选展示样式。此为 Form 配置，Form.Item 无法单独配置
+   */
+  requiredMark?: RequiredMark;
+  /**
+   自定义样式
+   */
+  style ?: React.CSSProperties;
+}
+
+type RenderChildren = (form: FormInstance) => React.ReactNode;
+type ChildrenType = RenderChildren | React.ReactNode;
+
+export interface FormItemProps extends Omit<FieldProps, 'children'> {
+  /**
+   自定义 `css` 类前缀
+   */
+  prefixCls?: string;
+  /**
+   自定义 `className`
+   */
+  className?: string;
+  /**
+   自定义样式
+   */
+  style?: React.CSSProperties;
+  /**
+   `label` 标签的文本
+   */
+  label?: string;
+  afterLabel?: React.ReactNode;
+  afterInput?: React.ReactNode;
+  /**
+   被包裹的元素
+   */
+  children?: ChildrenType;
+  /**
+   帮助信息
+   */
+  help?: React.ReactNode;
+  /**
+   自定义校验结果提示信息，如不设置则会根据校验规则自动生成
+   */
+  feedback?: React.ReactNode;
+  /**
+   自定义校验结果类型
+   */
+  feedbackType?: FormItemFeedbackType;
+  /**
+   必填样式设置。如不设置，则会根据校验规则自动生成
+   */
+  required?: boolean;
+  marker?: React.ReactNode;
+  /**
+   自定义校验图标
+   */
+  feedbackIcon?: React.ReactNode;
+  /**
+   设置子元素 label htmlFor 属性
+   */
+  htmlFor?: string;
+  /**
+   label 标签的宽度（width）
+   */
+  labelWidth?: number;
+  /**
+   input 控制项标签的宽度（width）
+   */
+  inputWidth?: number;
+  /**
+   配置 Form.Item 的 colon 的默认值。表示是否显示 label 后面的冒号 (只有在属性 layout 为 horizontal 时有效)
+   */
+  colon?: boolean;
+  /**
+   label 标签的文本对齐方式
+   */
+  labelAlign?: FormLabelAlign;
+  fieldKey?: React.Key | React.Key[];
+  }
+
+export interface FormContextProps {
+  name?: string;
+  layout?: FormLayout;
+  labelAlign?: FormLabelAlign;
+  labelWidth?: number;
+  inputWidth?: number;
+  requiredMark?: RequiredMark;
+  colon?: boolean;
+}

--- a/packages/components/src/components/form/style/demo.less
+++ b/packages/components/src/components/form/style/demo.less
@@ -1,0 +1,36 @@
+.gio-field-control-input .gio-btn {
+  margin-right: 12px;
+}
+
+.with-drawer .headline {
+  display: flex;
+  justify-content: space-between;
+
+  > div {
+    color: #242e59;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 22px;
+    letter-spacing: 0;
+
+    > i {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      margin-right: 8px;
+      color: #fff;
+      font-style: normal;
+      background-color: #3867f4;
+      border-radius: 50%;
+    }
+  }
+
+  > a {
+    color: #3867f4;
+    font-size: 12px;
+    line-height: 20px;
+    letter-spacing: 0;
+  }
+}

--- a/packages/components/src/components/list/List.stories.tsx
+++ b/packages/components/src/components/list/List.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import * as Icons from '@gio-design/icons';
+import List, { DragList } from './index'
+import Option from './option'
+import { IBaseListProps } from './interface'
+import './style'
+
+export default {
+    title: 'Components/Functional/List',
+    component: List,
+    subcomponents: { Option },
+} as Meta;
+
+const options = [
+    { value: 'a', label: '选择事件a' },
+    { value: 'b', label: '选择事件b', tooltip: 'test', disabled: true },
+    { value: 'c', label: '选择事件c' },
+    { value: 'd', label: '选择事件d', disabled: true },
+];
+const WrapperStyle = {
+    display: 'inline-block',
+    borderRadius: 6,
+    backgroundColor: '#FFFFFF',
+    boxShadow: '0 2px 14px 1px rgba(223,226,237,0.8)',
+};
+
+const Template : Story<IBaseListProps> = (args) => (
+  <div style={WrapperStyle}>
+    <List {...args} />
+  </div>
+);
+export const Default = Template.bind({});
+Default.args = {
+    dataSource: options,
+    width: 170,
+    height: 176,
+}
+
+
+const DragTemplate : Story<IBaseListProps> = (args) => (
+  <div style={WrapperStyle}>
+    <DragList {...args} />
+  </div>
+)
+const labelRenderer = (option: any) => {
+    return (
+      <>
+        <Icons.AppOutlined />
+        &nbsp;&nbsp;
+        {option.label}
+      </>
+    );
+};
+export const DragLists = DragTemplate.bind({});
+DragLists.args = {
+    dataSource: options,
+    width: 260,
+    height: 166,
+    labelRenderer: {labelRenderer},
+}

--- a/packages/components/src/components/list/interface.ts
+++ b/packages/components/src/components/list/interface.ts
@@ -3,31 +3,94 @@ import { ReactNode, CSSProperties } from 'react';
 type ListValueType = string | string[];
 
 export interface IBaseListProps {
+  /**
+   `list` 数据源
+   */
   dataSource: Option[];
+  /**
+   是否多选
+   */
   isMultiple?: boolean;
+  /**
+   是否保存选中状态, 多选模式下失效
+   */
   stateless?: boolean;
+  /**
+   选中触发的回调
+   */
   onChange?: (value: any) => void;
+  /**
+   选中的值
+   */
   value?: any;
+  /**
+   	列表宽度
+   */
   width?: number | string;
+  /**
+   	列表高度
+   */
   height?: number;
+  /**
+   包裹样式
+   */
   wrapStyle?: CSSProperties;
+  /**
+   前缀 `className` 样式类名
+   */
   prefixCls?: string;
+  /**
+   渲染列表项
+   */
   labelRenderer?: (option: Option, isGruop: false) => ReactNode;
+  /**
+   	自定义行高
+   */
   rowHeight?: number | ((option: Option) => number);
+  /**
+   选中的回调
+   */
   onSelect?: (selectedValue: string, value: ListValueType, option: Option) => void;
+  /**
+   	取消选中的回调
+   */
   onDeselect?: (selectedValue: string, value: ListValueType, option: Option) => void;
+  /**
+   	点击触发的回调
+   */
   onClick?: (value: any) => void;
   getPopupContainer?: (node: HTMLElement) => HTMLElement;
   placement?: string;
 }
 
 export interface Option {
+  /**
+   列表单项主要文字
+   */
   label: string;
+  /**
+   	作为列表的 `key` 来使用
+   */
   value: string;
+  /**
+   	列表次要文字
+   */
   description?: string;
+  /**
+   	是否禁用
+   */
   disabled?: boolean;
+  /**
+   	`tooltip` 描述
+   */
   tooltip?: string;
+  /**
+   分组的 `key` ，与 `groupLabel` 一起使用
+   */
   groupValue?: string;
+  /**
+   	分组的标题
+   */
   groupLabel?: string;
 }
 

--- a/packages/components/src/components/modal/Model.stories.tsx
+++ b/packages/components/src/components/modal/Model.stories.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Modal,{ IModalProps } from './index'
+import './style'
+import { Button } from '../..';
+
+export default {
+    title: 'Components/Functional/Modal',
+    component: Modal,
+} as Meta;
+
+const showModal = (args : IModalProps) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [visible, setVisible] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setVisible(true)}>Open Modal</Button>
+        <Modal
+          {...args}
+          visible={args.visible ? args.visible : visible}
+          onClose={() => {
+            setVisible(false);
+          }}
+          onOk={() => console.log('ok')}
+          afterClose={() => {
+              console.log('');
+          }}
+        >
+          Default Modal
+        </Modal>
+      </>
+    );
+};
+
+const Template : Story<IModalProps> = (args) => <>{showModal(args)}</>;
+export const Default = Template.bind({});
+Default.args = {
+    title: "title",
+}

--- a/packages/components/src/components/modal/interface.ts
+++ b/packages/components/src/components/modal/interface.ts
@@ -29,34 +29,89 @@ export interface IFooterProps {
 }
 
 export interface IModalProps extends ITitleProps, Omit<IFooterProps, 'useOk' | 'useClose'> {
+  /**
+   替代 `Modal` 组件 `class` 的 `gio-modal` 前缀
+   */
   prefixCls?: string;
+  /**
+   `Modal` 根节点 `className`
+   */
   className?: string;
+  /**
+   `Modal` `wrap` 的 `className`
+   */
   wrapClassName?: string;
+  /**
+   `Modal` 根节点的样式
+   */
   style?: CSSProperties;
+  /**
+   `Modal` `wrap` 内联样式
+   */
   wrapStyle?: Record<string, unknown>;
+  /**
+   `Modal` `body` 内联样式
+   */
   bodyStyle?: Record<string, unknown>;
+  /**
+   `Modal` `mask` 内联样式
+   */
   maskStyle?: Record<string, unknown>;
+  /**
+   `Modal` `body` `props`
+   */
   bodyProps?: Record<string, unknown>;
+  /**
+   `Modal` `mask` `props`
+   */
   maskProps?: Record<string, unknown>;
+  /**
+   `Modal wrap props`
+   */
   wrapProps?: Record<string, unknown>;
+  /**
+   	`Modal` 层级
+   */
   zIndex?: number;
+  /**
+   `Modal` 右上角关闭 `Icon`
+   */
   closeIcon?: ReactNode;
+  /**
+   被包裹的元素
+   */
   children?: ReactNode;
-  // 按 ESC 键是否可以关闭 Modal
+  /**
+   是否支持按 ESC 关闭 Modal
+   */
   keyboard?: boolean;
-  // Modal 的尺寸
+  /**
+   `Modal` 的尺寸
+   */
   size?: TModalSize;
-  // Modal 是否可见
+  /**
+   `Modal` 是否可见
+   */
   visible?: boolean;
-  // 弃用 Footer 中的 close Button
+  /**
+   是否不使用 `Footer` 中的关闭按钮
+   */
   dropCloseButton?: boolean;
-  // 组件 pending 状态
+  /**
+   组件 `pending` 状态
+   */
   pending?: boolean;
-  // 执行 close 后紧接着执行的操作
+  /**
+   执行 `close` 后紧接着执行的操作
+   */
   afterClose?: () => void;
-  // 点击 Ok 后是否要紧接着执行 close
+  /**
+   `Modal` `onOk` 执行后是否执行 `onClose`
+   */
   closeAfterOk?: boolean;
-  // 是否在 Modal 关闭后销毁
+  /**
+   `Modal` `onClose` 执行后是否卸载 `Modal` 组件
+   */
   destroyOnClose?: boolean;
   getContainer?: IStringOrHtmlElement | (() => IStringOrHtmlElement) | false;
   forceRender?: boolean;
@@ -74,33 +129,61 @@ export interface IStepModalNodeRenderProps {
 export type TModalNodeRender = ReactNode | ((renderProps: IStepModalNodeRenderProps) => ReactNode);
 
 export interface IStep {
-  // 当前 Step 的唯一标识
+  /**
+   当前 `Step` 的唯一标识
+   */
   key: string;
-  // 当前 Step 的上一步
+  /**
+   当前 Step 的上一步
+   */
   return: string | null;
-  // 多分支路径下，当前步骤是否是默认的下一步
+  /**
+   多分支路径下，当前步骤是否是默认的下一步
+   */
   firstNextInTier?: boolean;
-  // 多分支路径下的出口标识
+  /**
+   多分支路径下的出口标识
+   */
   wayout?: boolean;
-  // 下一步 回调
+  /**
+   下一步 回调
+   */
   onNext?: TStepNoParamFn;
-  // 上一步 回调
+  /**
+   上一步 回调
+   */
   onBack?: TStepNoParamFn;
-  // 当前步骤 Modal 的 Title
+  /**
+   当前步骤 `Modal` 的 `Title`
+   */
   title?: TModalNodeRender;
-  // 当前步骤 Modal 的 Body
+  /**
+   当前步骤 `Modal` 的 `Body`
+   */
   content?: TModalNodeRender;
-  // 当前步骤 Modal 的 Footer
+  /**
+   当前步骤 `Modal` 的 `Footer`
+   */
   footer?: TModalNodeRender;
-  // 同 Modal.footer
+  /**
+   除了 `OkButton` 及 `CloseButton` 外的自定义 `Footer`
+   */
   additionalFooter?: ReactNode;
-  // 下一步按钮的 props
+  /**
+   传递给下一步按钮的 props
+   */
   nextButtonProps?: ButtonProps;
-  // 上一步按钮的 props
+  /**
+   被包裹的	传递给上一步的 `props` 元素
+   */
   backButtonProps?: ButtonProps;
-  // 下一步按钮的 text
+  /**
+   传递给下一步按钮的显示文案
+   */
   nextText?: string;
-  // 上一步按钮的 text
+  /**
+   传递给上一步按钮的显示文案
+   */
   backText?: string;
 }
 

--- a/packages/components/src/components/pagination/Pagination.stories.tsx
+++ b/packages/components/src/components/pagination/Pagination.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Pagination, { PaginationProps } from './index'
+import './style'
+
+export default {
+    title: 'Components/Functional/Pagination',
+    component: Pagination,
+} as Meta;
+
+const Template : Story<PaginationProps> = (args) => <Pagination {...args} />;
+export const Default = Template.bind({});
+Default.args = {
+    total: 100,
+}

--- a/packages/components/src/components/pagination/interface.tsx
+++ b/packages/components/src/components/pagination/interface.tsx
@@ -1,14 +1,50 @@
 export interface PaginationProps {
+  /**
+   禁用分页组件
+   */
   disabled?: boolean;
+  /**
+   设置组件 CSS 类前缀
+   */
   prefixCls?: string;
+  /**
+   设置默认页
+   */
   defaultCurrent?: number;
+  /**
+   	设置当前页
+   */
   current?: number;
+  /**
+   	数据总数
+   */
   total?: number;
+  /**
+   	每页条数
+   */
   pageSize?: number;
+  /**
+   自定义 `className`
+   */
   className?: string;
+  /**
+   自定义样式
+   */
   style?: React.CSSProperties;
+  /**
+   页码改变的回调，参数是改变后的页码及每页条数
+   */
   onChange?: (page: number, pageSize: number) => void;
+  /**
+   用于显示数据总量和当前数据顺序
+   */
   showTotal?: (total: number, range: [number, number]) => React.ReactNode;
+  /**
+   用于快速跳转
+   */
   showQuickJumper?: boolean;
+  /**
+   只有一页时是否隐藏分页器
+   */
   hideOnSinglePage?: boolean;
 }

--- a/packages/components/src/components/popconfirm/Popconfirm.stories.tsx
+++ b/packages/components/src/components/popconfirm/Popconfirm.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Popconfirm, { PopconfirmProps } from './index'
+import './style'
+import { Button } from '../..';
+
+export default {
+    title: 'Components/Functional/Popconfirm',
+    component: Popconfirm,
+} as Meta;
+
+const Template : Story<PopconfirmProps> = (args) => (
+  <Popconfirm {...args}>
+    <Button>Click Me</Button>
+  </Popconfirm>
+);
+export const Default = Template.bind({});
+Default.args = {
+    title: '确定要删除。。。。吗？',
+    desc: '删除物品属性后，相关数据将停止计算，历史数据保留。',
+    placement: 'bottom',
+}

--- a/packages/components/src/components/popconfirm/interface.ts
+++ b/packages/components/src/components/popconfirm/interface.ts
@@ -1,11 +1,32 @@
 import { TooltipProps } from '../tooltip/interface';
 
 export interface PopconfirmProps extends Omit<TooltipProps, 'title' | 'tooltipLink'> {
+  /**
+   	确认框的主题
+   */
   title: string;
+  /**
+   	确认框的描述
+   */
   desc?: string;
+  /**
+   	点击取消的回调
+   */
   onCancel?: (e:React.MouseEvent<HTMLElement, MouseEvent>)=>void;
+  /**
+   	点击确认的回调
+   */
   onConfirm?: (e:React.MouseEvent<HTMLElement, MouseEvent>)=>void;
+  /**
+   	确认按钮文字
+   */
   okText?: string;
+  /**
+   		取消按钮文字
+   */
   cancelText?: string;
+  /**
+   	替换 title 前的 icon
+   */
   icon?: React.ReactNode;
 }

--- a/packages/components/src/components/popover/Popover.stories.tsx
+++ b/packages/components/src/components/popover/Popover.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+
+import Popover from './index'
+import { PopoverProps } from './interface'
+import './style'
+import './style/demo.less'
+import { Checkbox, CheckboxGroup } from '../..';
+
+export default {
+    title: 'Components/Functional/Popover',
+    component: Popover,
+} as Meta;
+
+const content = () => (
+  <>
+    <p className="title">广告阶段</p>
+    <CheckboxGroup>
+      <Checkbox value="1">点击</Checkbox>
+      <Checkbox value="2">到站访问</Checkbox>
+      <Checkbox value="3">到站访问率</Checkbox>
+    </CheckboxGroup>
+    <p className="title" style={{ marginTop: 32 }}>
+      用户量
+    </p>
+    <CheckboxGroup>
+      <Checkbox value="1">用户总量</Checkbox>
+      <Checkbox value="2">新增</Checkbox>
+      <Checkbox value="3">回访</Checkbox>
+    </CheckboxGroup>
+  </>
+)
+const text = () => (
+  <>
+    <input className="displayInput" />
+    <p className="desc">*此链接用于统计渠道点击数据，请用此链接替换点击跳转地址。</p>
+  </>
+
+)
+
+const Template : Story<PopoverProps> = (args) => (
+  <Popover {...args}>
+    <span className="popoverSpan">hover me</span>
+  </Popover>
+)
+export const Default = Template.bind({});
+Default.args = {
+    contentArea: content(),
+}
+
+
+export const ClickPopover = Template.bind({});
+ClickPopover.args = {
+    contentArea: text(),
+    footerArea: <span className="rightButton">复制链接</span>,
+    trigger: 'click',
+}

--- a/packages/components/src/components/popover/interface.ts
+++ b/packages/components/src/components/popover/interface.ts
@@ -2,6 +2,12 @@ import { TooltipProps } from '../tooltip/interface';
 
 export type ReactRender = () => React.ReactNode;
 export interface PopoverProps extends Omit<TooltipProps, 'title' | 'tooltipLink'> {
+  /**
+   	卡片内容区域
+   */
   contentArea: React.ReactNode | ReactRender;
+  /**
+   	卡片按钮区域
+   */
   footerArea?: React.ReactNode | ReactRender;
 }

--- a/packages/components/src/components/popover/style/demo.less
+++ b/packages/components/src/components/popover/style/demo.less
@@ -1,0 +1,95 @@
+.gio-popover-inner {
+  &-content {
+    .displayInput {
+      display: block;
+      width: 220px;
+      height: 30px;
+      background-color: #fff;
+      border: 1px solid #dcdfed;
+      border-radius: 4px;
+      &:focus {
+        outline: none;
+      }
+    }
+    .title {
+      color: #313e75;
+      font-size: 14px;
+    }
+    .desc {
+      width: 220px;
+      margin-top: 8px;
+      margin-bottom: 0;
+      color: #a3adc8;
+      font-size: 12px;
+    }
+  }
+  &-footer {
+    .button {
+      display: inline-block;
+      height: 30px;
+      padding: 4px 16px;
+      color: #fff;
+      font-size: 14px;
+      line-height: 22px;
+      letter-spacing: 0;
+      background-color: #3867f4;
+      border-radius: 4px;
+    }
+    .centerButton {
+      .button;
+      display: block;
+      width: 108px;
+      margin: 0 auto;
+    }
+    .rightButton {
+      .button;
+      float: right;
+    }
+  }
+}
+
+@button-width: 100px;
+.popoverSpan {
+  display: inline-block;
+  width: @button-width;
+  margin: 10px;
+  padding: 5px 8px;
+  text-align: center;
+  border: 1px solid #adadad;
+}
+
+.popoverSpanInLine {
+  display: inline-block;
+  margin: 10px;
+  padding: 5px 8px;
+  text-align: center;
+  border: 1px solid #adadad;
+}
+
+.popover-top {
+  margin-left: @button-width;
+  & > .tooltipSpan {
+    margin: 0 10px;
+  }
+}
+
+.popover-left {
+  float: left;
+  width: @button-width;
+  & > .tooltipSpan {
+    margin: 10px 0;
+  }
+}
+.popover-buttom {
+  margin-left: @button-width;
+  & > .tooltipSpan {
+    margin: 0 10px;
+  }
+}
+.popover-right {
+  width: @button-width;
+  margin-left: 450px;
+  & > .tooltipSpan {
+    margin: 10px 0;
+  }
+}


### PR DESCRIPTION
affects: @gio-design/components

add stories to some Functional components

## @gio-design/components@20.11.1

- 横幅/日期选择器/下拉菜单/表单/列表/弹窗/分页/气泡确认框/气泡卡片
  - 增加上述组件的story

---

## @gio-design/components@20.11.1

- Banner/DatePicker/Dropdown/Form/List/Modal/Pagination/Popconfirm/Popover
  - add stories to upper components
