### PR TITLE
fix(modal): fix modal height too high issue

### DIFF
--- a/packages/components/src/components/modal/style/modal.less
+++ b/packages/components/src/components/modal/style/modal.less
@@ -11,7 +11,7 @@
     bottom: 0;
     left: 0;
     z-index: 1050;
-    overflow: hidden;
+    overflow: auto;
     outline: 0;
     -webkit-overflow-scrolling: touch;
   }


### PR DESCRIPTION
affects: @gio-design/components

## @gio-design/components@20.11.3

- 弹窗
 - 修复弹窗高度过高时的问题

---

## @gio-design/components@20.11.3

- Modal
  - fix modal height too high issue

