### PR TITLE
refactor(components): add props exports for all components

### DIFF
--- a/packages/components/src/components/cascader/index.tsx
+++ b/packages/components/src/components/cascader/index.tsx
@@ -9,7 +9,9 @@ import Dropdown from '../dropdown';
 import Input from '../input';
 import Menu, { Props as MenuProps } from './menu';
 import SearchBar from './search-bar';
-import { Props } from './interface'
+import { Props } from './interface';
+
+export { Props as CascaderProps } from './interface';
 
 const Cascader: React.FC<Props> = (props) => {
   const {

--- a/packages/components/src/components/checkbox/index.tsx
+++ b/packages/components/src/components/checkbox/index.tsx
@@ -1,5 +1,13 @@
-import Checkbox from './checkbox';
+import GIOCheckbox from './checkbox';
+import CheckboxGroup from './group';
 
-export { default as CheckboxGroup } from './group';
-export { CheckboxGroupProps, CheckboxOptionType } from './interface';
+export type TCheckbox = typeof GIOCheckbox & {
+  Group: typeof CheckboxGroup;
+};
+
+const Checkbox = GIOCheckbox as TCheckbox;
+Checkbox.Group = CheckboxGroup;
+
+export { CheckboxProps, CheckboxGroupProps, CheckboxOptionType } from './interface';
+export { CheckboxGroup };
 export default Checkbox;

--- a/packages/components/src/components/grid/index.tsx
+++ b/packages/components/src/components/grid/index.tsx
@@ -5,6 +5,8 @@ import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 import { GridProps } from './interface';
 import { clip, dataMap, isNumber } from './help';
 
+export { GridProps } from './interface';
+
 const Grid: React.FC<GridProps> = (props: React.PropsWithChildren<GridProps>) => {
   const {
     component: Component = 'div',

--- a/packages/components/src/components/input/index.tsx
+++ b/packages/components/src/components/input/index.tsx
@@ -7,4 +7,5 @@ Input.InputNumber = InputNumber;
 Input.Password = Password;
 Input.TextArea = TextArea;
 
+export { InputProps, InputNumberProps, TextAreaProps } from './interfaces';
 export default Input;

--- a/packages/components/src/components/link/index.tsx
+++ b/packages/components/src/components/link/index.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 import classnames from 'classnames';
-import { TLinkProps } from './interface';
+import { LinkProps } from './interface';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 
-const Link: React.FC<TLinkProps> = ({
+export { LinkProps } from './interface';
+
+const Link: React.FC<LinkProps> = ({
   component = 'a',
   to = '',
   disabled,
@@ -12,7 +14,7 @@ const Link: React.FC<TLinkProps> = ({
   className,
   children,
   ...otherProps
-}: TLinkProps) => {
+}: LinkProps) => {
   const prefixCls = usePrefixCls('link', customPrefixCls);
   const cls = classnames(className, prefixCls, {
     [`${prefixCls}--disabled`]: disabled,

--- a/packages/components/src/components/link/interface.ts
+++ b/packages/components/src/components/link/interface.ts
@@ -5,19 +5,19 @@ export type HtmlElement = keyof React.ReactHTML;
 
 export interface ILinkProps {
   /**
-   自定义 Link 根元素使用的组件
+   * 自定义 Link 根元素使用的组件
    */
   component: React.ElementType;
   /**
-   跳转目标链接
+   * 跳转目标链接
    */
   to?: string;
   /**
-   失效状态
+   * 失效状态
    */
   disabled?: boolean;
   /**
-   替代 Link 组件 class 的 gio-link 前缀
+   * 替代 Link 组件 class 的 gio-link 前缀
    */
   prefix?: string;
 }
@@ -27,7 +27,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
   defaultComponent: D;
 }
 
-export type TLinkProps<D extends React.ElementType = LinkTypeMap['defaultComponent'], P = {}> = OverrideProps<
+export type LinkProps<D extends React.ElementType = LinkTypeMap['defaultComponent'], P = {}> = OverrideProps<
   LinkTypeMap<P, D>,
   D
 >;

--- a/packages/components/src/components/list/index.ts
+++ b/packages/components/src/components/list/index.ts
@@ -1,5 +1,14 @@
 import NormalList from './normal';
 import DragList from './drag';
 
-export default NormalList;
+export { IBaseListProps as ListProps, Option as ListOption } from './interface';
+
+type TList = typeof NormalList & {
+  DragList: typeof DragList;
+};
+
+const List = NormalList as TList;
+List.DragList = DragList;
+
 export { DragList };
+export default List;

--- a/packages/components/src/components/menu/index.tsx
+++ b/packages/components/src/components/menu/index.tsx
@@ -2,7 +2,12 @@ import GIOMenu from './Menu';
 import MenuItem from './MenuItem';
 import SubMenu from './SubMenu';
 
-export { IMenuProps, ISubMenuProps, IMenuItemProps, TMenuMode } from './interface';
+export {
+  IMenuProps as MenuProps,
+  ISubMenuProps as SubMenuProps,
+  IMenuItemProps as MenuItemProps,
+  TMenuMode as MenuMode,
+} from './interface';
 
 export type TMenu = typeof GIOMenu & {
   MenuItem: typeof MenuItem;

--- a/packages/components/src/components/modal/Model.stories.tsx
+++ b/packages/components/src/components/modal/Model.stories.tsx
@@ -1,40 +1,40 @@
 import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 
-import Modal,{ IModalProps } from './index'
-import './style'
+import Modal, { ModalProps } from './index';
+import './style';
 import { Button } from '../..';
 
 export default {
-    title: 'Components/Functional/Modal',
-    component: Modal,
+  title: 'Components/Functional/Modal',
+  component: Modal,
 } as Meta;
 
-const showModal = (args : IModalProps) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [visible, setVisible] = useState(false);
-    return (
-      <>
-        <Button onClick={() => setVisible(true)}>Open Modal</Button>
-        <Modal
-          {...args}
-          visible={args.visible ? args.visible : visible}
-          onClose={() => {
-            setVisible(false);
-          }}
-          onOk={() => console.log('ok')}
-          afterClose={() => {
-              console.log('');
-          }}
-        >
-          Default Modal
-        </Modal>
-      </>
-    );
+const showModal = (args: ModalProps) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [visible, setVisible] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setVisible(true)}>Open Modal</Button>
+      <Modal
+        {...args}
+        visible={args.visible ? args.visible : visible}
+        onClose={() => {
+          setVisible(false);
+        }}
+        onOk={() => console.log('ok')}
+        afterClose={() => {
+          console.log('');
+        }}
+      >
+        Default Modal
+      </Modal>
+    </>
+  );
 };
 
-const Template : Story<IModalProps> = (args) => <>{showModal(args)}</>;
+const Template: Story<ModalProps> = (args) => <>{showModal(args)}</>;
 export const Default = Template.bind({});
 Default.args = {
-    title: "title",
-}
+  title: 'title',
+};

--- a/packages/components/src/components/modal/index.tsx
+++ b/packages/components/src/components/modal/index.tsx
@@ -5,15 +5,15 @@ import useModal from './useModal';
 import { IModalStaticFuncConfig, IModalStaticFunctions, IUseModal } from './interface';
 
 export {
-  IModalProps,
-  IStepModalProps,
-  TModalSize,
-  IStep,
-  TStepChange,
-  IModalStaticFuncConfig,
-  IModalStaticFuncReturn,
-  TModalStaticFuncType,
-  IModalStaticFunc,
+  IModalProps as ModalProps,
+  IStepModalProps as StepModalProps,
+  TModalSize as ModalSize,
+  IStep as Step,
+  TStepChange as StepChange,
+  IModalStaticFuncConfig as ModalStaticFuncConfig,
+  IModalStaticFuncReturn as ModalStaticFuncReturn,
+  TModalStaticFuncType as ModalStaticFuncType,
+  IModalStaticFunc as ModalStaticFunc,
 } from './interface';
 
 export { StepModal, useModal };

--- a/packages/components/src/components/popover/index.tsx
+++ b/packages/components/src/components/popover/index.tsx
@@ -3,6 +3,8 @@ import Tooltip from '../tooltip';
 import { PopoverProps } from './interface';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 
+export { PopoverProps } from './interface';
+
 const Popover: React.FC<PopoverProps> = (props: PopoverProps) => {
   const { children, contentArea, footerArea, prefixCls: customizePrefixCls, subPrefixCls = 'popover', ...rest } = props;
   const prefixCls = usePrefixCls(subPrefixCls, customizePrefixCls);

--- a/packages/components/src/components/progress/index.tsx
+++ b/packages/components/src/components/progress/index.tsx
@@ -1,3 +1,5 @@
 import Progress from './Progress';
 
+export { ProgressProps } from './interface';
+
 export default Progress;

--- a/packages/components/src/components/radio/index.tsx
+++ b/packages/components/src/components/radio/index.tsx
@@ -3,6 +3,12 @@ import RadioGroup from './Group';
 
 Radio.Group = RadioGroup;
 
+export {
+  IRadioProps as RadioProps,
+  IRadioGroupProps as RadioGroupProps,
+  TRadioGroupOption as RadioGroupOption,
+} from './interface';
+
 export { RadioGroup };
 
 export default Radio;

--- a/packages/components/src/components/search-bar/index.tsx
+++ b/packages/components/src/components/search-bar/index.tsx
@@ -6,6 +6,8 @@ import { SearchBarProps } from './interfaces';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 import { SizeContext } from '../config-provider/SizeContext';
 
+export { SearchBarProps } from './interfaces';
+
 const getStorage = (key: string): string[] => {
   const empty: string[] = [];
   try {
@@ -108,8 +110,8 @@ const SearchBar: React.FC<SearchBarProps> = (props: SearchBarProps) => {
 
   // 按esc建关闭下拉框
   const handleKeyUp = (e: any) => {
-    (e.keyCode === 27) && handleBlur(e);
-  }
+    e.keyCode === 27 && handleBlur(e);
+  };
 
   const renderStorage = () => {
     if (!showStorage || !showDropdown) {
@@ -130,19 +132,24 @@ const SearchBar: React.FC<SearchBarProps> = (props: SearchBarProps) => {
             </Button>
           </div>
         )}
-        {searchStorage.slice((searchStorage.length - storageNum) >= 0 ? (searchStorage.length - storageNum) : 0, searchStorage.length).reverse().map((item) => (
-          <div
-            onClick={() => {
-              onChange(item);
-            }}
-            className={`${prefixCls}-dropdown-item`}
-            key={item}
-            aria-hidden="true"
-          >
-            {(value || searchValue) && <mark className={`${prefixCls}-dropdown-item-mark`}>{value || searchValue}</mark>}
-            {item.replace(value || searchValue,'')}
-          </div>
-        ))}
+        {searchStorage
+          .slice(searchStorage.length - storageNum >= 0 ? searchStorage.length - storageNum : 0, searchStorage.length)
+          .reverse()
+          .map((item) => (
+            <div
+              onClick={() => {
+                onChange(item);
+              }}
+              className={`${prefixCls}-dropdown-item`}
+              key={item}
+              aria-hidden="true"
+            >
+              {(value || searchValue) && (
+                <mark className={`${prefixCls}-dropdown-item-mark`}>{value || searchValue}</mark>
+              )}
+              {item.replace(value || searchValue, '')}
+            </div>
+          ))}
       </div>
     );
   };

--- a/packages/components/src/components/select/index.tsx
+++ b/packages/components/src/components/select/index.tsx
@@ -1,5 +1,14 @@
-import Select from './Select';
+import GIOSelect from './Select';
 import { Option } from './interface';
+
+export { SelectProps, Option as SelectOption } from './interface';
+
+type TSelect = typeof GIOSelect & {
+  Option: typeof Option;
+};
+
+const Select = GIOSelect as TSelect;
+Select.Option = Option;
 
 export { Option as SelectOptions };
 export default Select;

--- a/packages/components/src/components/sign/index.ts
+++ b/packages/components/src/components/sign/index.ts
@@ -1,3 +1,5 @@
 import Sign from './Sign';
 
+export { ISignProps as SignProps } from './interface';
+
 export default Sign;

--- a/packages/components/src/components/tabs/index.tsx
+++ b/packages/components/src/components/tabs/index.tsx
@@ -1,5 +1,14 @@
-import Tabs from './Tabs';
+import GIOTabs from './Tabs';
+import TabPane from './TabPane';
 
-export { default as TabPane } from './TabPane';
 export { TabProps, TabPaneProps } from './interface';
+
+type TTabs = typeof GIOTabs & {
+  Pane: typeof TabPane;
+};
+
+const Tabs = GIOTabs as TTabs;
+Tabs.Pane = TabPane;
+
+export { TabPane };
 export default Tabs;

--- a/packages/components/src/components/tag/index.tsx
+++ b/packages/components/src/components/tag/index.tsx
@@ -1,3 +1,5 @@
 import Tag from './Tag';
 
+export { TagProps } from './interface';
+
 export default Tag;

--- a/packages/components/src/components/time-picker/index.tsx
+++ b/packages/components/src/components/time-picker/index.tsx
@@ -4,6 +4,8 @@ import TimePicker from './TimePicker';
 import { TimePickerProps } from './interface';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 
+export { TimePickerProps } from './interface';
+
 export default ({ prefixCls: customizePrefixCls, ...props }: TimePickerProps) => {
   const prefixCls = usePrefixCls('time-picker', customizePrefixCls);
 

--- a/packages/components/src/components/toast/index.tsx
+++ b/packages/components/src/components/toast/index.tsx
@@ -16,6 +16,8 @@ import {
   NotificationInstance,
 } from './interface';
 
+export { ConfigOptions as ToastConfigOptions, TToastType as ToastType } from './interface';
+
 let key = 1;
 let toastInstance: NotificationInstance;
 let defaultDuration = 2;

--- a/packages/components/src/components/toggles/index.tsx
+++ b/packages/components/src/components/toggles/index.tsx
@@ -1,3 +1,5 @@
 import Toggles from './toggles';
 
+export { TogglesProps } from './interface';
+
 export default Toggles;

--- a/packages/components/src/components/upload/index.tsx
+++ b/packages/components/src/components/upload/index.tsx
@@ -1,13 +1,13 @@
 import Upload from './Upload';
 
 export {
-  IUploadProps,
+  IUploadProps as UploadProps,
+  TUploadType as UploadType,
+  TUploadStatus as UploadStatus,
   IRcFile,
   IUploadFile,
   IProgress,
   IRcCustomRequestOptions,
-  TUploadStatus,
-  TUploadType,
 } from './interface';
 
 export default Upload;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,52 +1,73 @@
-export { default as Alert } from './components/alert';
-export { default as Avatar, AvatarGroup } from './components/avatar';
-export { default as Banner } from './components/banner';
-export { default as Breadcrumb, BreadcrumbItem } from './components/breadcrumb';
-export { default as Button } from './components/button';
-export { default as Checkbox, CheckboxGroup } from './components/checkbox';
-export { default as Drawer } from './components/drawer';
-export { default as Dropdown } from './components/dropdown';
-export { default as Input } from './components/input';
-export { default as Link } from './components/link';
-export { default as Loading } from './components/loading';
-export { default as Menu } from './components/menu';
+export { default as Alert, AlertProps } from './components/alert';
+export { default as Avatar, AvatarGroup, AvatarProps } from './components/avatar';
+export { default as Banner, BannerProps } from './components/banner';
+export { default as Breadcrumb, BreadcrumbItem, BreadcrumbProps, BreadcrumbItemProps } from './components/breadcrumb';
+export { default as Button, ButtonProps, ButtonType } from './components/button';
+export {
+  default as Checkbox,
+  CheckboxGroup,
+  CheckboxProps,
+  CheckboxGroupProps,
+  CheckboxOptionType,
+} from './components/checkbox';
+export { default as Drawer, DrawerProps } from './components/drawer';
+export { default as Dropdown, DropdownProps } from './components/dropdown';
+export { default as Input, InputProps, InputNumberProps, TextAreaProps } from './components/input';
+export { default as Link, LinkProps } from './components/link';
+export { default as Loading, LoadingProps } from './components/loading';
+export { default as Menu, MenuProps, SubMenuProps, MenuItemProps, MenuMode } from './components/menu';
 export {
   default as Modal,
   StepModal,
   useModal,
-  IModalProps,
-  IStepModalProps,
-  TModalSize,
-  IStep,
-  TStepChange,
-  IModalStaticFuncConfig,
-  IModalStaticFuncReturn,
-  TModalStaticFuncType,
-  IModalStaticFunc,
+  ModalProps,
+  StepModalProps,
+  ModalSize,
+  Step,
+  StepChange,
+  ModalStaticFuncConfig,
+  ModalStaticFuncReturn,
+  ModalStaticFuncType,
+  ModalStaticFunc,
 } from './components/modal';
-export { default as Pagination } from './components/pagination';
-export { default as Popconfirm } from './components/popconfirm';
-export { default as Popover } from './components/popover';
-export { default as Progress } from './components/progress';
-export { default as Radio, RadioGroup } from './components/radio';
-export { default as Sign } from './components/sign';
-export { default as Skeleton } from './components/skeleton';
-export { default as Table } from './components/table';
-export { default as TabNav } from './components/tab-nav';
-export { default as SearchBar } from './components/search-bar';
-export { default as Tabs, TabPane } from './components/tabs';
-export { default as Tag } from './components/tag';
-export { default as Toast } from './components/toast';
-export { default as Toggles } from './components/toggles';
-export { default as Tooltip } from './components/tooltip';
-export { default as Tree } from './components/tree';
-export { default as Upload } from './components/upload';
-export { default as List } from './components/list';
-export { default as Select, SelectOptions } from './components/select';
-export { default as Form, FormLayout } from './components/form';
-export { default as TimePicker } from './components/time-picker';
-export { default as Grid } from './components/grid';
-export { default as Cascader } from './components/cascader';
+export { default as Pagination, PaginationProps } from './components/pagination';
+export { default as Popconfirm, PopconfirmProps } from './components/popconfirm';
+export { default as Popover, PopoverProps } from './components/popover';
+export { default as Progress, ProgressProps } from './components/progress';
+export { default as Radio, RadioGroup, RadioProps, RadioGroupProps, RadioGroupOption } from './components/radio';
+export { default as Sign, SignProps } from './components/sign';
+export {
+  default as Skeleton,
+  SkeletonProps,
+  SkeletonImageProps,
+  SkeletonAvatarProps,
+  SkeletonParagraphProps,
+} from './components/skeleton';
+export { default as Table, TableProps } from './components/table';
+export { default as TabNav, TabNavProps } from './components/tab-nav';
+export { default as SearchBar, SearchBarProps } from './components/search-bar';
+export { default as Tabs, TabPane, TabProps, TabPaneProps } from './components/tabs';
+export { default as Tag, TagProps } from './components/tag';
+export { default as Toast, ToastConfigOptions, ToastType } from './components/toast';
+export { default as Toggles, TogglesProps } from './components/toggles';
+export { default as Tooltip, TooltipProps, TooltipLink } from './components/tooltip';
+export {
+  default as Tree,
+  TreeProps,
+  TreeNodeNormal,
+  GioTreeNode,
+  GioTreeNodeMouseEvent,
+  GioTreeNodeExpandedEvent,
+  GioTreeNodeSelectedEvent,
+  GioTreeNodeProps,
+} from './components/tree';
+export { default as Upload, UploadProps, UploadType, UploadStatus } from './components/upload';
+export { default as List, ListProps, ListOption } from './components/list';
+export { default as Select, SelectOptions, SelectProps, SelectOption } from './components/select';
+export { default as Form, FormLayout, FormProps } from './components/form';
+export { default as TimePicker, TimePickerProps } from './components/time-picker';
+export { default as Grid, GridProps } from './components/grid';
+export { default as Cascader, CascaderProps } from './components/cascader';
 
 // provide config context
 export { ConfigContext, ConfigConsumer, withConfigConsumer } from './components/config-provider';


### PR DESCRIPTION
affects: @gio-design/components

## @gio-design/components

- 完善 components 根目录导出的 props 及其他相关类型
- 完善带有多个子组件的组件写法，对 babel-import-plugin 支持的动态加载更友好

