### PR TITLE
fix(table): fix onChange can't get latest pagination state

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
-    'pre-commit': 'pretty-quick --staged && lint-staged',
+    'pre-commit': 'lint-staged',
     'pre-push': 'yarn test',
     'commit-msg': 'commitlint -E HUSKY_GIT_PARAMS',
   },

--- a/packages/components/src/components/loading/Loading.tsx
+++ b/packages/components/src/components/loading/Loading.tsx
@@ -4,12 +4,12 @@ import useDebounceLoading from '../../utils/hooks/useDebounceLoading';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 import { LoadingProps } from './interface';
 
-const Loading: React.FC<LoadingProps> = (props: LoadingProps) => {
+const Loading = (props: LoadingProps) => {
   const { prefixCls: customizePrefixCls, loading = true, delay = 0 } = props;
   const prefixCls = usePrefixCls('loading', customizePrefixCls);
   const shouldLoading = useDebounceLoading(loading, delay);
 
-  const renderLoadingElement = () => {
+  const renderLoadingElement = (): React.ReactElement => {
     const { indicator } = props;
     if (indicator) {
       return <span className={`${prefixCls}-indicator`}>{indicator}</span>;

--- a/packages/components/src/components/loading/interface.ts
+++ b/packages/components/src/components/loading/interface.ts
@@ -22,7 +22,7 @@ export interface LoadingProps {
   /**
    设置被包裹的元素
    */
-  children?: React.ReactChild;
+  children?: React.ReactChild[] | React.ReactChild;
   /**
    自定义 `className`
    */

--- a/packages/components/src/components/loading/style/index.less
+++ b/packages/components/src/components/loading/style/index.less
@@ -10,17 +10,13 @@
 
   &-wrapper-loading {
     position: relative;
-    display: inline-flex;
   }
 
   &-wrapper-loading > & {
     position: absolute;
-    left: 50%;
+    top: 50%;
     z-index: 1;
-    align-items: center;
-    align-self: center;
     width: 100%;
-    transform: translateX(-50%);
   }
 
   &-container {

--- a/packages/components/src/components/table/Title.tsx
+++ b/packages/components/src/components/table/Title.tsx
@@ -10,10 +10,10 @@ import { SortOrder, TitleProps } from './interface';
 export const getNextSortDirection = (sortDirections: SortOrder[], current: SortOrder): SortOrder =>
   current === null ? sortDirections[0] : sortDirections[sortDirections.indexOf(current) + 1];
 
-const Title = <RecordType,>(props: TitleProps<RecordType>) => {
+const Title = <RecordType,>(props: TitleProps<RecordType>): React.ReactElement => {
   const { prefixCls, column, onTriggerStateUpdate } = props;
 
-  const renderSorter = () => {
+  const renderSorter = (): React.ReactNode => {
     const { sorterState, updateSorterStates } = props;
     if (isUndefined(sorterState)) {
       return null;
@@ -21,7 +21,7 @@ const Title = <RecordType,>(props: TitleProps<RecordType>) => {
     const { sortDirections = ['ascend', 'descend', null] } = column;
     const { sortOrder: sorterOrder } = sorterState;
 
-    const handleSorterChange = () => {
+    const handleSorterChange = (): void => {
       updateSorterStates({
         ...sorterState,
         sortOrder: getNextSortDirection(sortDirections, sorterOrder),
@@ -56,13 +56,13 @@ const Title = <RecordType,>(props: TitleProps<RecordType>) => {
     );
   };
 
-  const renderFilter = () => {
+  const renderFilter = (): React.ReactNode => {
     const { filterState, updateFilterStates } = props;
     if (isUndefined(filterState)) {
       return null;
     }
     const { filteredKeys, filters } = filterState;
-    const handleFilterPopoverClick = (newFilteredKeys: string[]) => {
+    const handleFilterPopoverClick = (newFilteredKeys: string[]): void => {
       updateFilterStates({ ...filterState, filteredKeys: newFilteredKeys });
       onTriggerStateUpdate(true);
     };
@@ -87,7 +87,7 @@ const Title = <RecordType,>(props: TitleProps<RecordType>) => {
     );
   };
 
-  const renderInfo = () => {
+  const renderInfo = (): React.ReactNode => {
     const { info } = column;
     if (isUndefined(info)) {
       return null;

--- a/packages/components/src/components/table/__test__/Table.test.js
+++ b/packages/components/src/components/table/__test__/Table.test.js
@@ -131,9 +131,40 @@ describe('Testing Table', () => {
   });
 
   test('props pagination', () => {
-    const wrapper = mount(getTable());
-    wrapper.setProps({ pagination: true });
+    const onChange = jest.fn();
+    const dataSource = Array.from({ length: 100 }, (_, key) => ({ a: key, b: key, c: key, d: key }));
+    const _columns = [
+      {
+        title: 'A',
+        dataIndex: 'a',
+        key: 'a',
+        width: 200,
+      },
+      {
+        title: 'B',
+        dataIndex: 'b',
+        key: 'b',
+        width: 200,
+      },
+      {
+        title: 'C',
+        dataIndex: 'c',
+        key: 'c',
+        width: 200,
+      },
+      {
+        title: 'D',
+        dataIndex: 'd',
+        key: 'd',
+        width: 200,
+      },
+    ];
+    const wrapper = mount(
+      <Table title="列表标题" dataSource={dataSource} columns={_columns} pagination={true} onChange={onChange} />
+    );
     expect(wrapper.exists('.gio-table-pagination')).toBe(true);
+    wrapper.find('.gio-pagination-item').at(1).simulate('click');
+    expect(onChange).toBeCalledWith({ current: 2, pageSize: 10 }, [], []);
   });
 
   it('should be render rightly', () => {

--- a/packages/components/src/components/table/hook/usePagination.tsx
+++ b/packages/components/src/components/table/hook/usePagination.tsx
@@ -19,7 +19,7 @@ const usePagination = <RecordType,>(
 ] => {
   const { current, pageSize, total, ...rest } = pagination || {};
   const [localCurrent, setLocalCurrent] = useControlledState<number>(current, 1);
-  const [localPageSize] = useControlledState<number>(pageSize, 10);
+  const [localPageSize, setLocalPageSize] = useControlledState<number>(pageSize, 10);
   const [controlledTotal, setControlledTotal] = useControlledState<number>(total, data.length);
   const prefixCls = usePrefixCls('table');
 
@@ -67,15 +67,20 @@ const usePagination = <RecordType,>(
     [localCurrent, localPageSize]
   );
 
-  const PaginationComponent = ({ onTriggerStateUpdate }: { onTriggerStateUpdate: () => void }) => (
+  const PaginationComponent = ({
+    onTriggerStateUpdate,
+  }: {
+    onTriggerStateUpdate: (reset?: boolean, paginationState?: PaginationState) => void;
+  }) => (
     <Pagination
       className={`${prefixCls}-pagination`}
       total={controlledTotal}
       current={localCurrent}
       pageSize={localPageSize}
-      onChange={(c) => {
-        setLocalCurrent(c);
-        onTriggerStateUpdate();
+      onChange={(_page, _pageSize) => {
+        setLocalCurrent(_page);
+        setLocalPageSize(_pageSize);
+        onTriggerStateUpdate(false, { current: _page, pageSize: _pageSize });
       }}
       {...rest}
     />

--- a/packages/components/src/components/table/interface.ts
+++ b/packages/components/src/components/table/interface.ts
@@ -109,4 +109,5 @@ export interface TableProps<RecordType> {
   onChange?: (pagination: PaginationState, sorter: SortState<RecordType>[], filters: FilterState<RecordType>[]) => void;
   showHover?: boolean;
   showHeader?: boolean;
+  loading?: boolean;
 }

--- a/packages/components/src/components/table/style/index.less
+++ b/packages/components/src/components/table/style/index.less
@@ -87,9 +87,6 @@
 
   &-tbody > tr {
     color: @color-text-table-body;
-    & > td {
-      height: 50px;
-    }
   }
 
   &-tbody > tr:last-child > &-cell {
@@ -102,7 +99,9 @@
   }
 
   &-tbody > tr > &-cell {
+    height: 50px;
     padding: 16px;
+    overflow-wrap: break-word;
     background-color: @color-background-table-body;
     border-top: 0.5px solid @color-border-table;
     border-right: unset;

--- a/packages/website/src/components/functional/table/demo/loading.tsx
+++ b/packages/website/src/components/functional/table/demo/loading.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Table, Button } from '@gio-design/components';
+import '@gio-design/components/es/components/table/style/index.css';
+import './index.less';
+
+const dataSource: any[] = [
+  {
+    key: '1',
+    name: '列表文本',
+    age: '列表文本',
+    address: '列表文本',
+  },
+  {
+    key: '2',
+    name: '列表文本',
+    age: '列表文本',
+    address: '列表文本',
+  },
+  {
+    key: '3',
+    name: '列表文本',
+    age: '列表文本',
+    address: '列表文本',
+  },
+];
+
+const columns = [
+  {
+    title: '列标题1',
+    dataIndex: 'name',
+    key: 'name',
+  },
+  {
+    title: '列标题2',
+    dataIndex: 'age',
+    key: 'age',
+  },
+  {
+    title: '列标题3',
+    dataIndex: 'address',
+    key: 'address',
+  },
+];
+
+export default () => {
+  const [loading, setLoading] = useState(true);
+  return (
+    <>
+      <Table loading={loading} title="列表加载" dataSource={dataSource} columns={columns} pagination={false} />
+      <Button onClick={() => setLoading(!loading)}>click me</Button>
+    </>
+  );
+};

--- a/packages/website/src/components/functional/table/index.zh-CN.md
+++ b/packages/website/src/components/functional/table/index.zh-CN.md
@@ -157,6 +157,10 @@ group:
 
 <code src='./demo/empty.tsx' >
 
+### 列表加载
+
+<code src='./demo/loading.tsx' >
+
 ### 分页
 
 <code src='./demo/pagination.tsx' title='分页' desc='分页, pagination设置false 关闭' >
@@ -182,6 +186,7 @@ group:
 | **onHeaderRow**  | 设置头部行属性                                 | function(column, index)                | -                    |
 | **showHover**    | 是否显示 hover 效果                            | boolean                                | true                 |
 | **showHeader**   | 是否显示 table head                            | boolean                                | true                 |
+| **loading**      | 页面是否加载中                                 | boolean                                | false                |
 
 ### Column
 


### PR DESCRIPTION
affects: @gio-design/components, website

ISSUES CLOSED: #570 #539

## @gio-design/package@version

- 列表
  - 修复 onChange 回调不能拿到最新的分页状态
  - 添加加载功能

---

## @gio-design/package@version

- Table
  - fix onChange can't get latest pagination state
  - add loading feature
