### PR TITLE
style(input/date_picker): change input disabled color

### DIFF
--- a/packages/components/src/components/date-picker/dateRangePicker.tsx
+++ b/packages/components/src/components/date-picker/dateRangePicker.tsx
@@ -15,7 +15,6 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
   const prefixCls = usePrefixCls('date-picker', customizePrefixCls);
 
   const calendarContainerRef = useRef(null);
-  const toggleContainer = useRef(null);
   const [open, setOpen] = useState(false);
   const [timeRange, setTimeRange] = useState(value);
   const [leftInputTimeRange, setLeftInputTimeRange] = useState('');
@@ -24,18 +23,6 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
   useEffect(() => {
     setTimeRange(value);
   }, [value]);
-
-  const handleBlur = (event: any) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if(open && !toggleContainer.current.contains(event.target)){
-      onCancel();
-    }
-  }
-
-  useEffect(() => {
-    window.addEventListener('click',handleBlur);
-  })
 
   const onSelect = (values: Array<Moment>): void => {
     setTimeRange(values);
@@ -136,7 +123,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
   );
 
   return (
-    <div className={classNames(`${prefixCls}-wrap-range`)} ref={toggleContainer}>
+    <div className={classNames(`${prefixCls}-wrap-range`)}>
       <RcDatePicker
         animation="slide-up"
         calendar={calendar}

--- a/packages/components/src/components/date-picker/style/index.less
+++ b/packages/components/src/components/date-picker/style/index.less
@@ -18,9 +18,6 @@
     height: 40px;
   }
 }
-.@{date-picker-prefix-cls}-wrap-range {
-  width: fit-content;
-}
 
 .@{date-picker-prefix-cls}-range-input {
   display: flex;

--- a/packages/components/src/components/input/style/index.less
+++ b/packages/components/src/components/input/style/index.less
@@ -61,7 +61,7 @@
     }
 
     &:disabled {
-      color: @palette-black-1;
+      color: @palette-black-2;
       background-color: @palette-gray-1;
       border-color: @color-border-input-disable;
       cursor: not-allowed;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -76,6 +76,12 @@ export { default as Form, FormLayout, FormProps } from './components/form';
 export { default as TimePicker, TimePickerProps } from './components/time-picker';
 export { default as Grid, GridProps } from './components/grid';
 export { default as Cascader, CascaderProps } from './components/cascader';
+export { 
+  default as DatePicker,
+  DateRangePicker,
+  DatePickerProps,
+  DateRangePickerProps,
+} from './components/date-picker';
 
 // provide config context
 export { ConfigContext, ConfigConsumer, withConfigConsumer } from './components/config-provider';


### PR DESCRIPTION
affects: @gio-design/components

change input disabled color and restore dateRangePicker's change

## @gio-design/components@20.12.1

- 输入框
  - 修改input输入框disabled时的颜色

- 日期选择器
  - dateRangePicker的失焦隐藏实现存在问题，先去掉
  - 将datePicker及dateRangePicker从index里导出

---

## @gio-design/components@20.12.1

- input
  - change input disabled color 
- datePicker
  - There is a problem with the defocus hiding implementation of daterangepicker, which is removed temporarily
  - export datePicker and dateRangePicker from index
