### PR TITLE
fix(date-picker): add onblur and remove onSelect from props

### DIFF
--- a/packages/components/src/components/date-picker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-picker/DatePicker.stories.tsx
@@ -15,9 +15,6 @@ const DatePickerDemo = (args : DatePickerProps) => {
     const onChange = (value: Moment | null) => {
       value && setTime(value);
     };
-    const onSelect = (value: Moment) => {
-      setTime(value);
-    };
     const disabledDate = (value: Moment) => {
       const date = moment(new Date()).add(-1, 'days')
       return value.isBefore(date);
@@ -29,7 +26,6 @@ const DatePickerDemo = (args : DatePickerProps) => {
           {...args}
           value={args.value ? args.value : time}
           onChange={args.onChange ? args.onChange : onChange}
-          onSelect={args.onSelect ? args.onSelect : onSelect}
           format={args.format ? args.format : format}
           showFooter={args.showFooter ? args.showFooter : true}
           disabledDate={args.disabledDate ? args.disabledDate : disabledDate}
@@ -54,9 +50,6 @@ const RangePickerDemo = (args : DateRangePickerProps) => {
     const onChange = (value: Array<Moment> | null) => {
       value && setTime(value);
     };
-    const onSelect = (value: Array<Moment>) => {
-      setTime(value);
-    };
     const renderExtraFooter = () => {
       return <div>extra footer</div>
     }
@@ -66,7 +59,6 @@ const RangePickerDemo = (args : DateRangePickerProps) => {
           renderExtraFooter={args.renderExtraFooter ? args.renderExtraFooter : renderExtraFooter} 
           value={args.value ? args.value : time}
           onChange={args.onChange ? args.onChange : onChange}
-          onSelect={args.onSelect ? args.onSelect : onSelect}
           format={args.format ? args.format : format}
           showFooter={args.showFooter ? args.showFooter : true}
           disabledDate={args.disabledDate ? args.disabledDate : disabledDates}

--- a/packages/components/src/components/date-picker/__tests__/date-picker.spec.js
+++ b/packages/components/src/components/date-picker/__tests__/date-picker.spec.js
@@ -4,7 +4,7 @@ import { mount, render } from 'enzyme';
 import moment from 'moment';
 import { noop } from 'lodash';
 import DatePicker from '..';
-import Button from '../../button/button';
+// import Button from '../../button/button';
 
 const format = 'YYYY/MM/DD';
 const VALUE = moment([2015, 5, 1]);
@@ -51,21 +51,21 @@ describe('DatePicker ui test', () => {
 });
 
 describe('DatePicker action Test', () => {
-  it('should trigger onSelect', () => {
-    const onSelect = jest.fn();
-    const wrapper = mount(
-      <DatePicker value={VALUE} onSelect={onSelect} format={format} showFooter={false} disabledDate={disabledDate} />
-    );
-    act(() => {
-      wrapper.find('.gio-input-content').simulate('click');
-    });
-    waitComponentRender(wrapper).then(() => {
-      act(() => {
-        wrapper.find('.gio-date-picker-date').at(0).simulate('click');
-      });
-      expect(onSelect).toHaveBeenCalled();
-    });
-  });
+  // it('should trigger onSelect', () => {
+  //   const onSelect = jest.fn();
+  //   const wrapper = mount(
+  //     <DatePicker value={VALUE} onSelect={onSelect} format={format} showFooter={false} disabledDate={disabledDate} />
+  //   );
+  //   act(() => {
+  //     wrapper.find('.gio-input-content').simulate('click');
+  //   });
+  //   waitComponentRender(wrapper).then(() => {
+  //     act(() => {
+  //       wrapper.find('.gio-date-picker-date').at(0).simulate('click');
+  //     });
+  //     expect(onSelect).toHaveBeenCalled();
+  //   });
+  // });
 
   /*
   it('should trigger onChange', () => {

--- a/packages/components/src/components/date-picker/datePicker.tsx
+++ b/packages/components/src/components/date-picker/datePicker.tsx
@@ -29,7 +29,6 @@ const DatePicker: React.FC<DatePickerProps> = (props: DatePickerProps) => {
   const onSelect = (values: Moment): void => {
     if (!props.showFooter) {
       setLocalValue(values);
-      props.onSelect?.(values);
       setOpen(false);
     }
   };
@@ -82,6 +81,11 @@ const DatePicker: React.FC<DatePickerProps> = (props: DatePickerProps) => {
     </>
   );
 
+  const onblur = () => {
+    showFooter && onCancel();
+    !showFooter && setOpen(false);
+  }
+
   const calendar = (
     <RcCalendar
       locale={zhCN}
@@ -98,7 +102,7 @@ const DatePicker: React.FC<DatePickerProps> = (props: DatePickerProps) => {
       showOk={false}
       disabledDate={disabledDate}
       renderFooter={renderFooter}
-      onBlur={onCancel}
+      onBlur={onblur}
     />
   );
 

--- a/packages/components/src/components/date-picker/dateRangePicker.tsx
+++ b/packages/components/src/components/date-picker/dateRangePicker.tsx
@@ -15,6 +15,7 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
   const prefixCls = usePrefixCls('date-picker', customizePrefixCls);
 
   const calendarContainerRef = useRef(null);
+  const selectPanelRef = useRef<any>(null);
   const [open, setOpen] = useState(false);
   const [timeRange, setTimeRange] = useState(value);
   const [leftInputTimeRange, setLeftInputTimeRange] = useState('');
@@ -26,7 +27,6 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
 
   const onSelect = (values: Array<Moment>): void => {
     setTimeRange(values);
-    props.onSelect?.(values);
     !showFooter && setOpen(false);
   };
 
@@ -102,6 +102,14 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
     </>
   );
 
+  const onblur = (e: any) => {
+    if(selectPanelRef.current && selectPanelRef.current.contains(e.nativeEvent.relatedTarget)){
+      return;
+    }
+    showFooter && onCancel();
+    !showFooter && setOpen(false);
+  }
+
   const formatDate = (v: Moment) => v.format(format);
 
   const calendar = (
@@ -123,9 +131,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = (props: DateRangePickerP
   );
 
   return (
-    <div className={classNames(`${prefixCls}-wrap-range`)}>
+    <div className={classNames(`${prefixCls}-wrap-range`)} onBlur={onblur} ref={selectPanelRef}>
       <RcDatePicker
-        animation="slide-up"
+        animation={showFooter ? "slide-up" : ''}
         calendar={calendar}
         value={timeRange}
         onChange={onChange}

--- a/packages/components/src/components/date-picker/interface.tsx
+++ b/packages/components/src/components/date-picker/interface.tsx
@@ -30,10 +30,6 @@ export interface DatePickerProps {
    */
   onChange?: (v: Moment | null) => void;
   /**
-   	选择日期的回调
-   */
-  onSelect?: (v: Moment) => void;
-  /**
    是否显示footer
    */
   showFooter: boolean;
@@ -72,10 +68,6 @@ export interface DateRangePickerProps {
    面板切换的回调
    */
   onChange?: (v: Array<Moment> | null) => void;
-  /**
-   	选择日期的回调
-   */
-  onSelect?: (v: Array<Moment>) => void;
   /**
    默认显示的时间
    */

--- a/packages/website/src/components/functional/date-picker/demo/base.tsx
+++ b/packages/website/src/components/functional/date-picker/demo/base.tsx
@@ -9,9 +9,6 @@ const Demo = () => {
   const onChange = (value: Moment | null) => {
     value && setTime(value);
   };
-  const onSelect = (value: Moment) => {
-    setTime(value);
-  };
 
   const disabledDate = (value: Moment) => {
     const date = moment(new Date()).add(-1, 'days')
@@ -25,7 +22,6 @@ const Demo = () => {
       <DatePicker
         value={time}
         onChange={onChange}
-        onSelect={onSelect}
         format={format}
         showFooter
         disabledDate={disabledDate}

--- a/packages/website/src/components/functional/date-picker/demo/range.tsx
+++ b/packages/website/src/components/functional/date-picker/demo/range.tsx
@@ -15,10 +15,6 @@ const Demo = () => {
   const onChange = (value: Array<Moment> | null) => {
     value && setTime(value);
   };
-  const onSelect = (value: Array<Moment>) => {
-    setTime(value);
-    console.log('outer', value[0].format(format), value[1].format(format));
-  };
 
   const renderExtraFooter = () => {
     return <div>extra footer</div>
@@ -26,7 +22,7 @@ const Demo = () => {
 
   return (
     <div style={{ boxSizing: 'border-box', position: 'relative', display: 'block', lineHeight: 1.5, marginBottom: 22 }}>
-      <DateRangePicker value={time} onChange={onChange} onSelect={onSelect} renderExtraFooter={renderExtraFooter} disabledDate={disabledDate} format={format} showFooter />
+      <DateRangePicker value={time} onChange={onChange} renderExtraFooter={renderExtraFooter} disabledDate={disabledDate} format={format} showFooter />
     </div>
   );
 };

--- a/packages/website/src/components/functional/date-picker/index.zh-CN.md
+++ b/packages/website/src/components/functional/date-picker/index.zh-CN.md
@@ -26,6 +26,5 @@ group:
 | **showFooter**  | 是否显示footer | boolean |    true    |
 | **format**  | 日期显示格式 | string |    'YYYY/MM/DD'    |
 | **onChange**  | 面板切换的回调 | () => void |        |
-| **onSelect**  | 选择日期的回调 | () => void |        |
 | **value**  | 此受控组件绑定的时间 | `Array<Moment> , Moment`  |        |
 


### PR DESCRIPTION
affects: @gio-design/components, website

add onblur to dateRangePicker and remove onSelect from props

## @gio-design/components, website@20.12.1

- 日期选择器
  - 给dateRangePicker设置失焦隐藏
  - 将onSelect从参数列表里删除
  - 修复dateRangePicker点击取消或者失焦时行为和点击确定按钮一样的问题

---

## @gio-design/components, website@20.12.1

- datePicker
  - Defocus setting for picker Ranger
  - Delete onSelect from props
  - Fixed the same behavior of daterangepicker when clicking cancel or defocus as when clicking OK
