### PR TITLE
style(radio): fix the radio style when radio-group is disabled

### DIFF
--- a/packages/components/src/components/radio/Radio.tsx
+++ b/packages/components/src/components/radio/Radio.tsx
@@ -18,10 +18,6 @@ const InnerRadio: React.ForwardRefRenderFunction<unknown, IRadioProps> = (
   const groupContext = useContext(RadioGroupContext);
   const prefixCls = usePrefixCls('radio', customPrefixCls);
 
-  const wrapperCls = classnames(className, `${prefixCls}__wrapper`, {
-    [`${prefixCls}__wrapper--checked`]: restProps.checked,
-    [`${prefixCls}__wrapper--disabled`]: restProps.disabled,
-  });
   const labelCls = classnames(`${prefixCls}__label`);
 
   const handleChange = (e: IRadioChangeEvent) => {
@@ -44,6 +40,11 @@ const InnerRadio: React.ForwardRefRenderFunction<unknown, IRadioProps> = (
     rcProps.name = groupContext.name;
     rcProps.disabled = groupContext.disabled || restProps.disabled;
   }
+
+  const wrapperCls = classnames(className, `${prefixCls}__wrapper`, {
+    [`${prefixCls}__wrapper--checked`]: restProps.checked,
+    [`${prefixCls}__wrapper--disabled`]: rcProps.disabled,
+  });
 
   return (
     // eslint-disable-next-line jsx-a11y/label-has-associated-control


### PR DESCRIPTION
affects: @gio-design/components

fix the radio style when radio-group is disabled

## @gio-design/components@20.12.3

- 单选框
  - 修复当radioGroup设置为disabled时，里面的radio仍可以触发hover动作，主要原因是Radio没有接收到RadioGroup传来的disabled属性，导致gio-radio__wrapper--disabled样式没有生效。

---

## @gio-design/components@20.12.3

- Radio
  - Fix that when the radio group is set to disabled, the radio in it can still trigger the hover action. The main reason is that the radio does not receive the disabled attribute from the radio group, resulting in the gio-radio__ Wrapper--disabled style does not work.
