### PR TITLE
fix(checkbox): fix the checkbox cursor when disabled

### DIFF
--- a/packages/components/src/components/checkbox/style/index.less
+++ b/packages/components/src/components/checkbox/style/index.less
@@ -76,6 +76,10 @@
     height: 100%;
     cursor: pointer;
     opacity: 0;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 
   display: inline-block;


### PR DESCRIPTION
affects: @gio-design/components

fix the checkbox cursor when disabled

## @gio-design/components@20.12.3

- 多选框
  - 修复checkbox在disabled状态时cursor仍为pointer的问题

---

## @gio-design/components@20.12.3

- checkbox
  - Fix the problem that the cursor is still a pointer when the checkbox is in the disabled state
