### PR TITLE
fix(modal): fix the modal click onOk don't close in CalloutModal

### DIFF
--- a/packages/components/src/components/modal/CalloutModal.tsx
+++ b/packages/components/src/components/modal/CalloutModal.tsx
@@ -37,6 +37,7 @@ const CalloutModal: React.FC<ICalloutModalProps> = ({
 
   const handleExecResult = (execResult: void | PromiseLike<any>) => {
     if (!execResult || !execResult.then) {
+      calloutClose();
       return;
     }
 


### PR DESCRIPTION
affects: @gio-design/components

fix the modal click onOk don't close in CalloutModal

## @gio-design/components@20.12.4

- 弹窗
  - 修复modal组件在函数式调用时点击确定按钮modal没有关闭的问题

---

## @gio-design/components@20.12.4

- Modal
  - Fix the problem that the modal component does not close when it clicks the OK button in the functional call
