### PR TITLE
feat(avatar): add default prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ yarn-error.log
 coverage
 .importjs.js
 storybook-static
+.idea

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-import { MoreOutlined } from '@gio-design/icons';
+import { MoreOutlined, UserOutlined } from '@gio-design/icons';
 import { isNil, isUndefined } from 'lodash';
 import Tooltip from '../tooltip';
 import { AvatarProps } from './interfaces';
@@ -9,6 +9,7 @@ import composeRef from '../../utils/composeRef';
 
 const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProps, ref: React.Ref<HTMLSpanElement>) => {
   const {
+    default: showDefault = false,
     className,
     size = 'default',
     droppable = false,
@@ -47,6 +48,9 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
     [`${prefixCls}-lg`]: size === 'large',
     [`${prefixCls}-hg`]: size === 'huge',
   });
+  const iconSizeMap: {[K: string]: string} = {
+    small: '10', 'default': '14', large: '24', huge: '35'
+  }
 
   const childrenStyle: React.CSSProperties = {
     transform: `scale(${scale}) translateX(-50%)`,
@@ -66,6 +70,13 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>((props: AvatarProp
   const renderAvatar = () => {
     if (!!src && isImgExist) {
       return <img alt="avatar" src={src} onError={() => setIsImgExist(false)} />;
+    }
+    if (showDefault) {
+      return (
+        <span className={`${prefixCls}-default`}>
+          <UserOutlined color="#fff" size={iconSizeMap[size]} />
+        </span>
+      )
     }
     if (userName !== undefined && typeof userName === 'string') {
       const prefixUserName = omit && typeof userName === 'string' ? userName.trim()[0].toUpperCase() : userName.trim();

--- a/src/components/avatar/__tests__/Avatar.test.js
+++ b/src/components/avatar/__tests__/Avatar.test.js
@@ -71,6 +71,11 @@ describe('Testing Avatar', () => {
     expect(wrapper.exists('.gio-tooltip-placement-top')).toBe(true);
   });
 
+  test('props default',  () => {
+    const wrapper = mount(<Avatar default>这是一个很长的文字</Avatar>);
+    expect(wrapper.exists('.gio-avatar-default')).toBeTruthy();
+  })
+
   it('can accept dropdown trigger Mouse Event', () => {
     const wrapper = mount(
       <Dropdown overlay={<div>11</div>}>

--- a/src/components/avatar/interfaces.ts
+++ b/src/components/avatar/interfaces.ts
@@ -23,6 +23,10 @@ export interface AvatarProps {
    */
   src?: string;
   /**
+   * 是否在不存在src时显示默认头像，显示默认头像将不显示文字
+   */
+  default?: boolean;
+  /**
    是否省略用户名称
    */
   omit?: boolean;

--- a/src/components/avatar/style/index.less
+++ b/src/components/avatar/style/index.less
@@ -20,6 +20,23 @@
     }
   }
 
+  &-default {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    background-color: #3867f4;
+
+    & svg {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      margin: auto;
+    }
+  }
+
   &-droppable {
     position: absolute;
     top: 0;


### PR DESCRIPTION
set the default property to true to display the default avatar when there is no src.

设置default:true后，会使用UserOutlined形式的默认头像