### PR TITLE
fix(tree-select): 解决slide动画引发的bug

### DIFF
--- a/src/components/time-picker/__tests__/Combobox.test.js
+++ b/src/components/time-picker/__tests__/Combobox.test.js
@@ -27,4 +27,18 @@ describe('Testing Combobox', () => {
       ).exists('.gio-time-picker-panel-combobox')
     ).toMatchSnapshot();
   });
+
+  it('props test2', () => {
+    const onClickMock = jest.fn();
+    expect(
+      mount(
+        <Combobox
+          defaultOpenValue={false}
+          use12Hours={false}
+          isAM
+          onAmPmChange={onClickMock}
+        />
+      ).exists('.gio-time-picker-panel-combobox')
+    ).toMatchSnapshot();
+  });
 });

--- a/src/components/time-picker/__tests__/__snapshots__/Combobox.test.js.snap
+++ b/src/components/time-picker/__tests__/__snapshots__/Combobox.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Testing Combobox props test 1`] = `false`;
 
+exports[`Testing Combobox props test2 1`] = `false`;
+
 exports[`Testing Combobox should match alert base snapshot. 1`] = `
 initialize {
   "0": Object {

--- a/src/components/tree-select/TreeSelect.tsx
+++ b/src/components/tree-select/TreeSelect.tsx
@@ -20,8 +20,6 @@ class TreeSelect<T> extends React.Component<TreeSelectProps<T>> {
   public static SHOW_CHILD: typeof SHOW_CHILD = SHOW_CHILD;
 
   public static defaultProps = {
-    transitionName: 'slide-up',
-    choiceTransitionName: '',
     bordered: true,
   };
 


### PR DESCRIPTION
tree-select组件引入了slide动画，但是不知道什么时候，slide动画的样式被删除了还是咋滴，反正就出问题了。所以tree-select组件也就不引入slide动画了