### PR TITLE
feat: support babel-plugin-import

### DIFF
--- a/src/components/col/index.ts
+++ b/src/components/col/index.ts
@@ -1,0 +1,4 @@
+import { Col, ColProps } from '../grid';
+
+export { ColProps };
+export default Col;

--- a/src/components/col/style/index.less
+++ b/src/components/col/style/index.less
@@ -1,19 +1,7 @@
 @import '../../../stylesheet/index.less';
 
-@row-prefix-cls: ~'@{component-prefix}-row';
 @col-prefix-cls: ~'@{component-prefix}-col';
-
 @grid-column-number: 12;
-
-.@{row-prefix-cls} {
-  display: flex;
-  flex-direction: var(--gio-grid-direction, row);
-  flex-wrap: var(--gio-grid-wrap, wrap);
-  align-content: var(--gio-grid-align-content, stretch);
-  align-items: var(--gio-grid-align-items, stretch);
-  justify-content: var(--gio-grid-justify, flex-start);
-  box-sizing: border-box;
-}
 
 .@{col-prefix-cls} {
   box-sizing: border-box;

--- a/src/components/col/style/index.ts
+++ b/src/components/col/style/index.ts
@@ -1,0 +1,1 @@
+import './index.less';

--- a/src/components/grid/Grid.stories.tsx
+++ b/src/components/grid/Grid.stories.tsx
@@ -3,7 +3,8 @@ import { Meta, Story } from '@storybook/react/types-6-0';
 import { Row, Col } from './index';
 import { RowProps, ColProps } from './interface';
 import './style/index.less';
-import './style/row.less';
+import '../row/style';
+import '../col/style';
 import './style/demo.stories.less';
 
 export default {

--- a/src/components/grid/style/index.ts
+++ b/src/components/grid/style/index.ts
@@ -1,2 +1,2 @@
 import './index.less';
-import './row.less';
+

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -14,11 +14,13 @@ export {
 export type TMenu = typeof GIOMenu & {
   MenuItem: typeof MenuItem;
   SubMenu: typeof SubMenu;
+  Divider: typeof Divider;
 };
 
 const Menu = GIOMenu as TMenu;
 Menu.MenuItem = MenuItem;
 Menu.SubMenu = SubMenu;
+Menu.Divider = Divider;
 
 export default Menu;
 export { MenuItem, SubMenu, Divider };

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -23,6 +23,7 @@ export type TModal = typeof GioModal &
   IModalStaticFunctions & {
     config: (configs: IModalConfigs) => void;
     useModal: IUseModal;
+    StepModal: typeof StepModal;
   };
 
 const Modal = GioModal as TModal;
@@ -40,5 +41,7 @@ Modal.error = (config: IModalStaticFuncConfig) => callout(withError(config));
 Modal.useModal = useModal;
 
 Modal.config = configModal;
+
+Modal.StepModal = StepModal;
 
 export default Modal;

--- a/src/components/row/index.ts
+++ b/src/components/row/index.ts
@@ -1,0 +1,4 @@
+import { Row, RowProps } from '../grid';
+
+export { RowProps };
+export default Row;

--- a/src/components/row/style/index.less
+++ b/src/components/row/style/index.less
@@ -1,0 +1,13 @@
+@import '../../../stylesheet/index.less';
+
+@row-prefix-cls: ~'@{component-prefix}-row';
+
+.@{row-prefix-cls} {
+  display: flex;
+  flex-direction: var(--gio-grid-direction, row);
+  flex-wrap: var(--gio-grid-wrap, wrap);
+  align-content: var(--gio-grid-align-content, stretch);
+  align-items: var(--gio-grid-align-items, stretch);
+  justify-content: var(--gio-grid-justify, flex-start);
+  box-sizing: border-box;
+}

--- a/src/components/row/style/index.ts
+++ b/src/components/row/style/index.ts
@@ -1,0 +1,1 @@
+import './index.less';

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,9 @@ export {
 } from './components/select';
 export { default as Form, FormLayout, FormProps } from './components/form';
 export { default as TimePicker, TimePickerProps } from './components/time-picker';
-export { default as Grid, GridProps, Row, Col, RowProps, ColProps } from './components/grid';
+export { default as Grid, GridProps } from './components/grid';
+export { default as Row, RowProps } from './components/row';
+export { default as Col, ColProps } from './components/col';
 export { default as Cascader, CascaderProps } from './components/cascader';
 export {
   default as DatePicker,


### PR DESCRIPTION
good 
import { Tab } from '@gio-design/component'
then use Tab and Tab.Pane 

bad 
import { Tab, TabPane } from '@gio-design/component'

bad
import Tab from  '@gio-design/component/es/compoents/tab';

close #901 
