### PR TITLE
fix(list-picker): selection consumer render children

### DIFF
--- a/src/list-picker/demos/List-picker.stories.tsx
+++ b/src/list-picker/demos/List-picker.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import '../style';
 import { uniqueId } from 'lodash';
+import CheckboxItem from '../../list/inner/ChckboxItem';
 import { OptionProps } from '../../list/interfance';
 // import { uniqueId } from 'lodash';
 // import { uniqBy, uniqueId } from 'lodash';
@@ -38,6 +39,10 @@ const Template: Story<ListPickerProps> = () => {
   const [multipleValue, setMultipleValue] = useState<undefined | string[]>(undefined);
   const [activeTab, setActiveTab] = useState('tab1');
   const [search, setSearch] = useState('');
+  const multipleOptions = [
+    { label: '子一', value: 'ziyi' },
+    { label: '子二', value: 'zier' },
+  ];
   const onChange = (val?: string, opt?: OptionProps | OptionProps[]) => {
     setValue(val);
     console.log('onChange执行', val, opt, search);
@@ -47,7 +52,7 @@ const Template: Story<ListPickerProps> = () => {
       <h3>单选</h3>
       <div className="demo-box">
         <div style={{ padding: '10px' }}>
-          <Button size="small" onClick={() => setValue(undefined)}>
+          <Button size="small" onClick={() => setValue('')}>
             清空
           </Button>
         </div>
@@ -56,7 +61,7 @@ const Template: Story<ListPickerProps> = () => {
           onChange={onChange}
           overlayStyle={{ width: '240px' }}
           onClear={() => {
-            // setValue(undefined);
+            setValue('');
           }}
           triggerProps={{ allowClear: true }}
           placeholder="请选择"
@@ -175,6 +180,7 @@ const Template: Story<ListPickerProps> = () => {
               placeholder="请搜索名称"
               onSearch={(val: string) => setSearch(val)}
             />
+
             <List.Selection
               options={[
                 { label: '子一', value: 'ziyi' },
@@ -183,6 +189,7 @@ const Template: Story<ListPickerProps> = () => {
             />
           </ListPicker>
         </div>
+        <h3>不同全选的方式</h3>
         <div className="demo-box">
           <div style={{ padding: '10px' }}>
             <Button size="small" onClick={() => setMultipleValue(['ziyi', 'zier'])}>
@@ -211,17 +218,75 @@ const Template: Story<ListPickerProps> = () => {
               placeholder="请搜索名称"
               onSearch={(val: string) => setSearch(val)}
             />
-            <List.Selection
-              options={[
-                { label: '子一', value: 'ziyi' },
-                { label: '子二', value: 'zier' },
-              ]}
-            />
+
+            <List.Selection>
+              {(context) => (
+                <>
+                  <CheckboxItem
+                    selected={context.value?.length === 2}
+                    onClick={() => {
+                      if (context.value?.length === 2) {
+                        context.onChange([]);
+                      } else {
+                        context.onChange(['ziyi', 'zier']);
+                      }
+                    }}
+                    label="全部"
+                    value="all"
+                  />
+                  <List options={multipleOptions} id="id" title="有item" />
+                </>
+              )}
+            </List.Selection>
           </ListPicker>
         </div>
-
+        <h3>selection下list 无 item</h3>
+        <div className="demo-box">
+          <ListPicker overlayStyle={{ width: '240px' }} placeholder="请选择" onChange={(v) => console.log('v', v)}>
+            <SearchBar
+              size="small"
+              style={{ width: '100%' }}
+              placeholder="请搜索名称"
+              onSearch={(val: string) => setSearch(val)}
+            />
+            <List.Selection>
+              <List options={multipleOptions} id="id" title="有item" />
+              <List options={[]} id="id2" title="无item" />
+              <List id="id3" title="有JSX item">
+                <List.Item value="id3-1">JSX-1</List.Item>
+                <List.Item value="id3-2">JSX-2</List.Item>
+              </List>
+            </List.Selection>
+          </ListPicker>
+        </div>
+        <h3>超长的ListPicker</h3>
         <div className="demo-box">
           <ListPicker
+            value={multipleValue}
+            onChange={(val) => {
+              console.log('multiple onChange 并不会触发', val);
+            }}
+            overlayStyle={{ width: '240px' }}
+            model="multiple"
+            onClear={() => {
+              setMultipleValue(undefined);
+            }}
+            onConfim={(val) => setMultipleValue(val as any)}
+            placeholder="请选择"
+          >
+            <SearchBar
+              size="small"
+              style={{ width: '100%' }}
+              placeholder="请搜索名称"
+              onSearch={(val: string) => setSearch(val)}
+            />
+            <List.Selection options={largeOptions} />
+          </ListPicker>
+        </div>
+        <h3>disabled</h3>
+        <div className="demo-box">
+          <ListPicker
+            disabled
             value={multipleValue}
             onChange={(val) => {
               console.log('multiple onChange 并不会触发', val);

--- a/src/list-picker/interfance.ts
+++ b/src/list-picker/interfance.ts
@@ -4,11 +4,12 @@ import { OptionProps } from '../list/interfance';
 import { Placement, TriggerAction } from '../popover/interface';
 import { ListProps } from '../list';
 
-export interface ListPickerProps extends Pick<ListProps, 'model' | 'disabled' | 'className' | 'style'> {
+export interface ListPickerProps extends Pick<ListProps, 'model' | 'className' | 'style'> {
   size?: 'small' | 'normal';
   /**
    * 触发方式
    */
+  disabled?: boolean;
   trigger?: TriggerAction | TriggerAction[];
   value?: string | string[];
   defaultValue?: string | string[];
@@ -23,10 +24,7 @@ export interface ListPickerProps extends Pick<ListProps, 'model' | 'disabled' | 
   /**
    * 触发器样式
    */
-  triggerProps?: Pick<
-    InputButtonProps,
-    'disabled' | 'className' | 'style' | 'allowClear' | 'maxWidth' | 'value' | 'prefix' | 'suffix'
-  >;
+  triggerProps?: Pick<InputButtonProps, 'className' | 'style' | 'allowClear' | 'maxWidth' | 'prefix' | 'suffix'>;
   /**
    * custom trigger render
    */
@@ -48,6 +46,7 @@ export interface ListPickerProps extends Pick<ListProps, 'model' | 'disabled' | 
 // }
 
 export interface TriggerProps extends Omit<InputButtonProps, 'value' | 'active'> {
+  disabled?: boolean;
   value?: string | React.ReactNode;
   separator?: string;
 }

--- a/src/list-picker/listPicker.tsx
+++ b/src/list-picker/listPicker.tsx
@@ -10,6 +10,7 @@ import { OptionProps } from '../list/interfance';
 import Button from '../button';
 import { ListContext } from '../list/context';
 import useCacheOptions from '../list/hooks/useCacheOptions';
+// import CheckboxItem from '../list/inner/ChckboxItem';
 
 // const defaultEmpty = () => <Page type="noData" size="small" style={{ margin: '0 auto', padding: '40px 0px' }} />;
 
@@ -17,6 +18,7 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
   const {
     size,
     placeholder,
+    disabled,
     onClear,
     value: controlledValue,
     defaultValue,
@@ -53,7 +55,9 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
   }, [controlledValue, getLabelByValue, separator, options]);
 
   useEffect(() => {
-    setValue(controlledValue);
+    if (!needConfim) {
+      setValue(controlledValue);
+    }
   }, [controlledValue, needConfim, setValue]);
   useEffect(() => {
     if (needConfim && !visible && !isEqual(controlledValue, value)) {
@@ -72,12 +76,11 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
   };
 
   const handleChange = (val?: string | string[], opts?: OptionProps | OptionProps[]) => {
-    setValue(val);
-    if (!needConfim) {
-      onChange?.(val, opts);
-    }
     if (model !== 'multiple') {
+      onChange?.(val, opts);
       handVisibleChange(false);
+    } else {
+      setValue(val);
     }
   };
   const clearInput = () => {
@@ -95,7 +98,7 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
         onClick={() => setVisible(!visible)}
         value={title}
         {...triggerProp}
-        // disabled={disabled}
+        disabled={disabled}
         size={size}
         placeholder={placeholder}
         onClear={clearInput}
@@ -103,10 +106,10 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
       />
     );
   };
-
   // render
   const renderOverlay = () => (
     <div className={classNames(defaultPrefix, className)} style={style}>
+      {/* {model === 'multiple' && selectAll && renderSelectAll()} */}
       {children}
       {model === 'multiple' && needConfim && (
         <Button style={{ width: '100%' }} onClick={() => handleConfim()}>
@@ -120,6 +123,7 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
     <ListContext.Provider value={{ value, model, onChange: handleChange, options, setOptions }}>
       <Popover
         distoryOnHide={false}
+        disabled={disabled}
         content={renderOverlay()}
         trigger={trigger}
         visible={visible}

--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { difference, indexOf, isArray, isEmpty, isNil } from 'lodash';
+import { difference, indexOf, isArray, isEmpty, isNil, toArray } from 'lodash';
 import { OptionProps, ItemProps, ListProps } from './interfance';
 import usePrefixCls from '../utils/hooks/use-prefix-cls';
 import { PREFIX } from './constants';
@@ -74,7 +74,7 @@ const List: React.ForwardRefRenderFunction<HTMLDivElement, ListProps> & {
     setOptions(mergedOptions);
   }, [mergedOptions, setOptions]);
 
-  const renderOptions = initOptions?.length ? initOptions : React.Children.toArray(children);
+  const renderOptions = initOptions?.length ? initOptions : toArray(children);
   const childrens = renderOptions.slice(0, collapse);
   const isNeedCollapse = useMemo(() => renderOptions?.length > collapse, [renderOptions, collapse]);
   const handleClick = (val: string) => {

--- a/src/list/Selection.tsx
+++ b/src/list/Selection.tsx
@@ -1,57 +1,86 @@
 import classNames from 'classnames';
 import React, { useMemo } from 'react';
-import { ListProps, SelectionProps } from './interfance';
+import { isEmpty, isFunction } from 'lodash';
+import toArray from 'rc-util/lib/Children/toArray';
+import { ListProps, SelectionProps, OptionProps } from './interfance';
 import usePrefixCls from '../utils/hooks/use-prefix-cls';
 import { PREFIX } from './constants';
 import { getFlattenOptions } from '../list-picker/util';
 import List from './List';
-import { OptionProps } from '.';
+import { ListContext } from './context';
 
-const Selection: React.FC<SelectionProps> & { isSelection: boolean } = (props) => {
+const Selection: React.FC<SelectionProps> = (props) => {
   const { className, style, options = [], children, ...rest } = props;
   const prefixCls = `${usePrefixCls(PREFIX)}--selection`;
-  const childrens = React.Children.toArray(children);
   const isSelection = options?.every((val) => 'groupId' in val) ?? false;
   const selectionOptions: { groupId: string; groupName: string; options: OptionProps[] }[] | OptionProps[] = useMemo(
     () => getFlattenOptions(options, isSelection),
     [isSelection, options]
   );
-  // var cars = [{ make: 'audi', model: 'r8', year: '2012' }, { make: 'audi', model: 'rs5', year: '2013' }, { make: 'ford', model: 'mustang', year: '2012' }, { make: 'ford', model: 'fusion', year: '2015' }, { make: 'kia', model: 'optima', year: '2012' }],
-  // result = cars.reduce(function (r, a) {
-  //     r[a.make] = r[a.make] || [];
-  //     r[a.make].push(a);
-  //     return r;
-  // }, Object.create(null));
 
-  // console.log(result);
   if (options.length) {
     return (
       <div className={classNames(prefixCls, className)} style={style}>
         {isSelection &&
-          (selectionOptions as { groupId: string; groupName: string; options: OptionProps[] }[])?.map((option) => (
-            <div className={`${prefixCls}--item`}>
-              {option?.groupId && <div className={`${prefixCls}--title`}>{option?.groupName}</div>}
-              <List options={option.options} />
-            </div>
-          ))}
-        {!isSelection && <List options={selectionOptions as OptionProps[]} />}
+          (selectionOptions as { groupId: string; groupName: string; options: OptionProps[] }[])?.map(
+            (option) =>
+              !isEmpty(option.options) && (
+                <div className={`${prefixCls}--item`}>
+                  {option?.groupId && <div className={`${prefixCls}--title`}>{option?.groupName}</div>}
+                  <List options={option.options} />
+                </div>
+              )
+          )}
+        {!isSelection && !isEmpty(selectionOptions) && <List options={selectionOptions as OptionProps[]} />}
       </div>
     );
   }
-
+  if (isFunction(children)) {
+    return (
+      <div className={classNames(prefixCls, className)} style={style}>
+        <ListContext.Consumer>
+          {(context) =>
+            toArray(children?.(context))?.map((node: React.ReactElement<ListProps>) =>
+              !isEmpty(node?.props.options) ||
+              React.isValidElement(node.props.children) ||
+              !isEmpty(toArray(node.props.children)) ? (
+                <div className={`${prefixCls}--item`}>
+                  {node?.props?.title && <div className={`${prefixCls}--title`}>{node?.props?.title}</div>}
+                  {React.cloneElement(node, {
+                    ...rest,
+                    ...node.props,
+                  })}
+                </div>
+              ) : (
+                React.cloneElement(node, {
+                  ...rest,
+                  ...node.props,
+                })
+              )
+            )
+          }
+        </ListContext.Consumer>
+      </div>
+    );
+  }
   return (
     <div className={classNames(prefixCls, className)} style={style}>
-      {childrens?.map((node: React.ReactElement<ListProps>) => (
-        <div className={`${prefixCls}--item`}>
-          {node?.props?.title && <div className={`${prefixCls}--title`}>{node?.props?.title}</div>}
-          {React.cloneElement(node, {
-            ...rest,
-            ...node.props,
-          })}
-        </div>
-      ))}
+      {toArray(children)?.map(
+        (node: React.ReactElement<ListProps>) =>
+          (!isEmpty(node?.props.options) ||
+            React.isValidElement(node.props.children) ||
+            !isEmpty(toArray(node.props.children))) && (
+            <div className={`${prefixCls}--item`}>
+              {node?.props?.title && <div className={`${prefixCls}--title`}>{node?.props?.title}</div>}
+              {React.cloneElement(node, {
+                ...rest,
+                ...node.props,
+              })}
+            </div>
+          )
+      )}
     </div>
   );
 };
-Selection.isSelection = true;
+
 export default Selection;

--- a/src/list/context.tsx
+++ b/src/list/context.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { List } from '.';
 import { OptionProps, ListProps } from './interfance';
 
-interface ListContextProps {
+export interface ListContextProps {
   value?: string | string[];
   model?: 'single' | 'cascader' | 'multiple';
   onChange?: (value?: string | string[], options?: OptionProps | OptionProps[]) => void;

--- a/src/list/hooks/useCacheOptions.ts
+++ b/src/list/hooks/useCacheOptions.ts
@@ -35,7 +35,7 @@ const useCacheOptions = () => {
 
   const getLabelByValue = (val?: string | string[], separator = '') => {
     if (val === '' || typeof val === 'undefined') {
-      return undefined;
+      return '';
     }
     if (val?.includes('.')) {
       return (val as any)
@@ -46,7 +46,7 @@ const useCacheOptions = () => {
     if (isArray(val)) {
       return val?.reduce((prev, curr: string) => [...prev, getOptionByValue?.(curr)?.label], [])?.join(',');
     }
-    return getOptionByValue(val)?.label;
+    return getOptionByValue(val)?.label ?? '';
   };
   return {
     options: options.current,

--- a/src/list/inner/CascaderItem.tsx
+++ b/src/list/inner/CascaderItem.tsx
@@ -2,6 +2,7 @@ import React, { DOMAttributes, useContext, useEffect, useMemo } from 'react';
 import { isEmpty, noop } from 'lodash';
 import { RightFilled } from '@gio-design/icons';
 import classNames from 'classnames';
+import toArray from 'rc-util/lib/Children/toArray';
 import Popover from '../../popover';
 import { CascaderItemProps, OptionProps, ListProps } from '../interfance';
 import BaseItem from './baseItem';
@@ -65,7 +66,7 @@ const CascaderItem: React.ForwardRefRenderFunction<
         model: 'cascader',
         disabled,
         className: classNames(children.props?.className, prefixCls),
-        children: React.Children.toArray(children?.props.children).map((child) =>
+        children: toArray(children?.props.children).map((child) =>
           React.cloneElement<OptionProps>(child as React.ReactElement, {
             selectParent: childSelectPrent,
           })

--- a/src/list/interfance.ts
+++ b/src/list/interfance.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ListContextProps } from './context';
 
 export type ModelType = 'cascader' | 'multiple' | 'single';
 
@@ -6,6 +7,7 @@ export interface SelectionProps extends ListProps {
   className?: string;
   style?: React.CSSProperties;
   options?: SelectionItemProps[] | OptionProps[];
+  children?: ((context: ListContextProps) => JSX.Element | React.ReactNode) | React.ReactNode;
 }
 
 export interface SelectionItemProps extends OptionProps {


### PR DESCRIPTION
1. 新增selection consumer  渲染 children的方式，为了支持全部这种操作
2. listPicker 单选模式下脱离非受控模式，当为单选模式时，遵循完全受控模式
3. listPicker 提升disabled层级，trigger的disabled交给listPicker来控制