### PR TITLE
fix(style): clear up all trigger style controls

### DIFF
--- a/src/cascader/Cascader.tsx
+++ b/src/cascader/Cascader.tsx
@@ -19,7 +19,6 @@ export const Cascader: React.FC<CascaderProps> = ({
   prefixCls = 'cascader-',
   getContainer,
   onVisibleChange,
-  triggerProps,
   className,
   style,
   prefix,
@@ -34,6 +33,15 @@ export const Cascader: React.FC<CascaderProps> = ({
   placement = 'bottomLeft',
   children,
   strategy = 'fixed',
+  onClear,
+  allowClear,
+  title: controlledTitle,
+  placeholder,
+  triggerPrefix,
+  triggerSuffix,
+  maxWidth,
+  hidePrefix,
+  renderTrigger: propsRenderTrigger,
   ...rest
 }) => {
   const defaultPrefixCls = usePrefixCls(prefixCls);
@@ -60,29 +68,35 @@ export const Cascader: React.FC<CascaderProps> = ({
   };
 
   const handleOnClear = (e: React.MouseEvent<Element, MouseEvent>) => {
+    onClear?.();
     handVisibleChange(false);
     e.stopPropagation();
   };
 
-  const renderTrigger = () => (
-    <div
-      className={classNames(`${defaultPrefixCls}-trigger`, className)}
-      style={style}
-      aria-hidden="true"
-      onClick={() => !disabled && setVisible(!visible)}
-    >
+  const renderTrigger = () => {
+    if (typeof propsRenderTrigger === 'function') {
+      return propsRenderTrigger?.();
+    }
+    return (
       <Trigger
-        value={title}
+        value={controlledTitle ?? title}
+        placeholder={placeholder}
+        prefix={!hidePrefix ? triggerPrefix : undefined}
+        suffix={triggerSuffix}
+        maxWidth={maxWidth}
         size={size}
+        style={style}
+        className={className}
         disabled={disabled}
+        allowClear={allowClear}
         onClear={handleOnClear}
+        onClick={() => !disabled && setVisible(!visible)}
         onInputChange={(val) => {
           isEmpty(val) && handleChange();
         }}
-        {...triggerProps}
       />
-    </div>
-  );
+    );
+  };
   const renderOverlay = () => (
     <List
       {...rest}

--- a/src/cascader/Trigger.tsx
+++ b/src/cascader/Trigger.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import Input from '../input';
+import WithRef from '../utils/withRef';
 import { TriggerProps } from './interfance';
 
-const Trigger: React.FC<TriggerProps> = (props) => {
+const Trigger: React.ForwardRefRenderFunction<HTMLInputElement, TriggerProps> = (props, ref) => {
   const { value, placeholder, ...rest } = props;
-  return <Input.Button placeholder={placeholder} value={value} {...rest} />;
+  return <Input.Button placeholder={placeholder} ref={ref} value={value} {...rest} />;
 };
 
-export default Trigger;
+export default WithRef(Trigger);

--- a/src/cascader/demos/Cascader.stories.tsx
+++ b/src/cascader/demos/Cascader.stories.tsx
@@ -82,7 +82,7 @@ const demoTemplate: Story<CascaderProps> = (props) => (
       <Cascader
         onChange={(val: any, opt: any) => console.log('val', val, opt)}
         options={defaultOptions}
-        triggerProps={{ placeholder: '请选择' }}
+        placeholder="请选择"
         size="normal"
         {...props}
       />
@@ -91,7 +91,8 @@ const demoTemplate: Story<CascaderProps> = (props) => (
     <div className="demo-box">
       <Cascader
         onChange={(val: any, opt: any) => console.log('val', val, opt)}
-        triggerProps={{ placeholder: '请选择', allowClear: false }}
+        placeholder="请选择"
+        allowClear={false}
         size="normal"
         {...props}
       >
@@ -114,7 +115,9 @@ const demoTemplate: Story<CascaderProps> = (props) => (
         onChange={(val: any, opt: any) => console.log('val', val, opt)}
         options={options}
         contentStyle={{ width: 240 }}
-        triggerProps={{ placeholder: '请选择', allowClear: false, style: { width: 240, textAlign: 'left' } }}
+        style={{ width: '100%', textAlign: 'left' }}
+        placeholder="请选择"
+        allowClear={false}
         size="small"
         {...props}
       />
@@ -125,7 +128,8 @@ const demoTemplate: Story<CascaderProps> = (props) => (
         onChange={(val: any, opt: any) => console.log('val', val, opt)}
         options={options}
         overlayStyle={{ width: 240 }}
-        triggerProps={{ placeholder: '请选择', style: { width: 240, textAlign: 'left' } }}
+        style={{ width: '100%', textAlign: 'left' }}
+        placeholder="请选择"
         size="small"
         {...props}
       />
@@ -138,10 +142,9 @@ const demoTemplate: Story<CascaderProps> = (props) => (
         prefix={() => <PlusOutlined size="14px" />}
         suffix={() => <FilterOutlined size="14px" />}
         overlayStyle={{ width: 240 }}
-        triggerProps={{
-          placeholder: '请选择',
-          style: { width: 240, textAlign: 'left' },
-        }}
+        placeholder="请选择"
+        allowClear={false}
+        style={{ width: 240, textAlign: 'left' }}
         size="small"
         {...props}
       />
@@ -156,6 +159,6 @@ export const Demo = demoTemplate.bind({
   },
 });
 export const Default: Story<CascaderProps> = (args) => (
-  <Cascader {...args} options={defaultOptions} triggerProps={{ placeholder: '请选择' }} size="normal" />
+  <Cascader {...args} options={defaultOptions} placeholder="请选择" size="normal" />
 );
 Default.args = {};

--- a/src/cascader/interfance.ts
+++ b/src/cascader/interfance.ts
@@ -7,14 +7,9 @@ export interface CascaderProps extends Omit<ListProps, 'options' | 'onChange' | 
   defaultValue?: string;
   options: OptionProps[];
   size?: 'small' | 'normal';
-  /**
-     多级文本的连接字符
-     */
-  separator?: string;
   visible?: boolean;
   onVisibleChange?: (visible: boolean) => void;
   prefixCls?: string;
-  triggerProps: Omit<TriggerProps, 'prefixCls' | 'onInputChange' | 'disabled' | 'getOptionByValue' | 'separator'>;
   onChange?: (val?: string | string[], options?: OptionProps | OptionProps[]) => void;
   getContainer?: (node: HTMLElement) => HTMLElement;
   overlayClassName?: string;
@@ -26,6 +21,44 @@ export interface CascaderProps extends Omit<ListProps, 'options' | 'onChange' | 
   contentStyle?: React.CSSProperties;
   placement?: Placement;
   strategy?: 'fixed' | 'absolute';
+  /** ================ trigger 相关的属性 ============== */
+  /**
+   * trigger className
+   */
+  className?: string;
+  /**
+   * trigger style
+   */
+  style?: React.CSSProperties;
+  /**
+   * 自定义title
+   */
+  title?: string;
+  placeholder?: string;
+  /**
+   * 自定义前缀icon
+   */
+  triggerPrefix?: React.ReactNode;
+  /**
+   * 自定义后缀的icon
+   */
+  triggerSuffix?: React.ReactNode;
+  maxWidth?: number;
+  hidePrefix?: boolean;
+
+  /**
+   * cascader 级联文本连接符
+   */
+  separator?: string;
+  /**
+   * 是否允许clear
+   */
+  allowClear?: boolean;
+  onClear?: (e?: React.MouseEvent<Element, MouseEvent>) => void;
+  /**
+   * custom trigger render
+   */
+  renderTrigger?: () => React.ReactElement;
 }
 export interface OptionProps extends ListOptionProps {
   label: string;

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -33,6 +33,10 @@ export function Dropdown<T = HTMLElement>(props: DropdownProps, ref: React.Forwa
         (child as React.ReactElement).props.className,
         ref
       ),
+      onClick: (...arg: any) => {
+        setControlledVisible(!controlledVisible);
+        (child as React.ReactElement).props.onClick?.(...arg);
+      },
     });
   };
 

--- a/src/input/Input.tsx
+++ b/src/input/Input.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { InputProps } from './interface';
 import usePrefixCls from '../utils/hooks/use-prefix-cls';
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
+const Input = React.forwardRef<HTMLSpanElement, InputProps>((props, ref) => {
   const {
     size,
     prefix: customizePrefix,
@@ -16,11 +16,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     onKeyPress,
     style,
     value,
+    inputRef: propsInputRef,
     ...rest
   } = props;
 
   const prefixCls = usePrefixCls('input', customizePrefixCls);
-
   const inputClass = useMemo(
     () =>
       classNames(
@@ -71,7 +71,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     [suffixCls, customizeSuffix]
   );
   return (
-    <span className={inputClass} {...rest} style={style}>
+    <span className={inputClass} {...rest} style={style} ref={ref}>
       {prefix}
       <input
         {...rest}
@@ -79,7 +79,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         disabled={disabled}
         onKeyPress={handleKeyPress}
         placeholder={placeholder}
-        ref={ref}
+        ref={propsInputRef}
       />
       {suffix}
     </span>

--- a/src/input/demos/Input.stories.tsx
+++ b/src/input/demos/Input.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { action } from '@storybook/addon-actions';
 import { PlusOutlined, FilterOutlined, EventsPresetOutlined } from '@gio-design/icons';
@@ -273,11 +273,24 @@ InputButtonDemo.args = {
   placeholder: '请选择事件',
 };
 
-const InputButtonDefaultTemplate = () => <InputButton />;
+const InputButtonDefaultTemplate = (arg: InputButtonProps) => {
+  const ref = useRef(undefined);
+  console.log('ref', ref);
+  return (
+    <InputButton
+      {...arg}
+      ref={ref}
+      onClick={(e) => {
+        console.log('onClick', e?.target);
+      }}
+    />
+  );
+};
 export const InputButtonDefault = InputButtonDefaultTemplate.bind({});
 InputButtonDefault.args = {
   allowClear: false,
   prefix: <EventsPresetOutlined />,
+  placeholder: '请选择',
   onChange: () => action('onChange'),
 };
 

--- a/src/input/interface.ts
+++ b/src/input/interface.ts
@@ -25,6 +25,10 @@ export interface BaseInputProps
    * 当点击回车键时调用
    */
   onPressEnter?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  /**
+   * inputRef
+   */
+  inputRef?: React.Ref<HTMLInputElement>;
 }
 
 export interface InputProps extends Omit<BaseInputProps, 'onChange'> {

--- a/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/FilterAttrOverlay.tsx
+++ b/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/FilterAttrOverlay.tsx
@@ -156,13 +156,8 @@ function FilterAttrOverlay(props: FilterAttrOverlayProps) {
               : selectOptionMap?.[valueType]
           }
           value={operationValue}
-          style={{ marginTop: '16px' }}
-          triggerProps={{
-            placeholder: '请选择',
-            style: {
-              width: '100%',
-            },
-          }}
+          style={{ marginTop: '16px', width: '100%' }}
+          placeholder="请选择"
           onChange={selectChange}
         />
         <Divider style={{ margin: '14px 0 16px' }} />

--- a/src/list-picker/Trigger.tsx
+++ b/src/list-picker/Trigger.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import Input from '../input';
+import WithRef from '../utils/withRef';
 import { TriggerProps } from './interfance';
 
-const Trigger: React.FC<TriggerProps> = (props) => {
+const Trigger: React.ForwardRefRenderFunction<HTMLInputElement, TriggerProps> = (props, ref) => {
   const { value, placeholder, onClear, ...rest } = props;
   const handleClear = (e: React.MouseEvent<Element, MouseEvent>) => {
     onClear?.(e);
     e.stopPropagation();
   };
-  return <Input.Button placeholder={placeholder} value={(value as string) ?? ''} onClear={handleClear} {...rest} />;
+  return (
+    <Input.Button ref={ref} placeholder={placeholder} value={(value as string) ?? ''} onClear={handleClear} {...rest} />
+  );
 };
 
-export default Trigger;
+export default WithRef(Trigger);

--- a/src/list-picker/demos/List-picker.stories.tsx
+++ b/src/list-picker/demos/List-picker.stories.tsx
@@ -72,10 +72,11 @@ const Template: Story<ListPickerProps> = () => {
           value={value}
           onChange={onChange}
           overlayStyle={{ width: '240px' }}
+          style={{ width: '100%' }}
           onClear={() => {
             setValue('');
           }}
-          triggerProps={{ allowClear: true }}
+          allowClear
           placeholder="请选择"
         >
           <SearchBar

--- a/src/list-picker/interfance.ts
+++ b/src/list-picker/interfance.ts
@@ -4,7 +4,7 @@ import { OptionProps } from '../list/interfance';
 import { Placement, TriggerAction } from '../popover/interface';
 import { ListProps } from '../list';
 
-export interface ListPickerProps extends Pick<ListProps, 'model' | 'className' | 'style'> {
+export interface ListPickerProps extends Pick<ListProps, 'model'> {
   size?: 'small' | 'normal';
   /**
    * 触发方式
@@ -15,30 +15,66 @@ export interface ListPickerProps extends Pick<ListProps, 'model' | 'className' |
   defaultValue?: string | string[];
   onChange?: (value?: string | string[], options?: OptionProps | OptionProps[]) => void;
   prefixCls?: string;
-  placeholder?: string;
-  /**
-   * cascader 级联文本连接符
-   */
-  separator?: string;
-  onClear?: (e?: React.MouseEvent<Element, MouseEvent>) => void;
-  /**
-   * 触发器样式
-   */
-  triggerProps?: Pick<InputButtonProps, 'className' | 'style' | 'allowClear' | 'maxWidth' | 'prefix' | 'suffix'>;
-  /**
-   * custom trigger render
-   */
-  renderTrigger?: () => React.ReactElement;
   visible?: boolean;
   onVisibleChange?: (visible: boolean) => void;
   getContainer?: (node: HTMLElement) => HTMLElement;
   needConfim?: boolean;
   confimText?: string;
   onConfim?: (value: string | string[] | undefined, options?: OptionProps | OptionProps[]) => void;
-  hidePrefix?: boolean;
+
   placement?: Placement;
-  overlayStyle?: React.CSSProperties;
+  /**
+   * 卡片类名
+   */
   overlayClassName?: string;
+  /**
+   * 卡片样式
+   */
+  overlayStyle?: React.CSSProperties;
+  /**
+   * contentClassName?:string;
+   */
+  contentClassName?: string;
+  contentStyle?: React.CSSProperties;
+
+  /** ================ trigger 相关的属性 ============== */
+  /**
+   * trigger className
+   */
+  className?: string;
+  /**
+   * trigger style
+   */
+  style?: React.CSSProperties;
+  /**
+   * 自定义title
+   */
+  title?: string;
+  placeholder?: string;
+  /**
+   * 自定义前缀icon
+   */
+  triggerPrefix?: React.ReactNode;
+  /**
+   * 自定义后缀的icon
+   */
+  triggerSuffix?: React.ReactNode;
+  maxWidth?: number;
+  hidePrefix?: boolean;
+
+  /**
+   * cascader 级联文本连接符
+   */
+  separator?: string;
+  /**
+   * 是否允许clear
+   */
+  allowClear?: boolean;
+  onClear?: (e?: React.MouseEvent<Element, MouseEvent>) => void;
+  /**
+   * custom trigger render
+   */
+  renderTrigger?: () => React.ReactElement;
 }
 
 // export interface StaticListPickerProps extends Omit<ListProps, 'options'> {

--- a/src/list-picker/listPicker.tsx
+++ b/src/list-picker/listPicker.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { isEqual, isNil, isString, omit } from 'lodash';
+import { isEqual, isNil, isString } from 'lodash';
 import { ListPickerProps } from './interfance';
 import Popover from '../popover';
 import Trigger from './Trigger';
@@ -24,40 +24,47 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
     visible: controlledVisible,
     onVisibleChange,
     onChange,
-    triggerProps,
     renderTrigger: propsRenderTrigger,
     prefixCls = 'list-picker-',
     getContainer,
     placement = 'bottomLeft',
-    overlayStyle,
-    overlayClassName,
     children,
     onConfim,
     confimText = '确定',
     separator = '',
-    className,
     style,
+    overlayStyle,
+    contentStyle,
+    className,
+    overlayClassName,
+    contentClassName,
     model = 'single',
     needConfim = model === 'multiple',
+
+    allowClear,
+    title: controlledTitle,
+    triggerPrefix,
+    triggerSuffix,
     hidePrefix = false,
+    maxWidth,
   } = props;
   const defaultPrefix = usePrefixCls(prefixCls);
   const [visible, setVisible] = useControlledState(controlledVisible, false);
   const [value, setValue] = useState(controlledValue || defaultValue);
-  const [title, setTitle] = useState<string | React.ReactNode>(undefined);
-  const [triggerPrefix, setTriggerPrefix] = useState<string | React.ReactNode>(undefined);
+  const [title, setTitle] = useState<string | React.ReactNode>(controlledTitle);
+  const [titlePrefix, setTitlePrefix] = useState<string | React.ReactNode>(undefined);
   const { options, setOptions, getLabelByValue, getOptionByValue, getOptionsByValue } = useCacheOptions();
 
   // title仅跟随controlledValue变动
   useEffect(() => {
     setTitle(getLabelByValue(controlledValue, separator));
-  }, [controlledValue, getLabelByValue, separator]);
+  }, [controlledValue, getLabelByValue, separator, setTitle]);
   // prefix
   useEffect(() => {
     if (model === 'single' && isString(controlledValue) && !hidePrefix) {
-      setTriggerPrefix(getOptionByValue(controlledValue)?.prefix ?? triggerProps?.prefix);
+      setTitlePrefix(triggerPrefix ?? getOptionByValue(controlledValue)?.prefix);
     }
-  }, [controlledValue, getOptionByValue, hidePrefix, model, triggerProps?.prefix]);
+  }, [controlledValue, getOptionByValue, hidePrefix, model, triggerPrefix]);
   useEffect(() => {
     setValue(controlledValue);
   }, [controlledValue, setValue]);
@@ -96,27 +103,30 @@ const ListPicker: React.FC<ListPickerProps> = (props) => {
   };
   // trigger
   const renderTrigger = (): React.ReactElement => {
-    const triggerProp = { size, placeholder, onClear, separator, ...omit(triggerProps, 'prefix') };
     if (typeof propsRenderTrigger === 'function') {
       return propsRenderTrigger?.();
     }
     return (
       <Trigger
-        onClick={() => setVisible(!visible)}
-        value={title}
-        prefix={triggerPrefix}
-        {...triggerProp}
-        disabled={disabled}
         size={size}
+        value={controlledTitle ?? title}
+        style={style}
+        className={className}
+        maxWidth={maxWidth}
+        disabled={disabled}
         placeholder={placeholder}
+        suffix={triggerSuffix}
+        prefix={titlePrefix}
+        allowClear={allowClear}
         onClear={clearInput}
         separator={separator}
+        onClick={() => !disabled && setVisible(!visible)}
       />
     );
   };
   // render
   const renderOverlay = () => (
-    <div className={classNames(defaultPrefix, className)} style={style}>
+    <div className={classNames(defaultPrefix, contentClassName)} style={contentStyle}>
       {/* {model === 'multiple' && selectAll && renderSelectAll()} */}
       {children}
       {model === 'multiple' && needConfim && (

--- a/src/list-picker/style/index.less
+++ b/src/list-picker/style/index.less
@@ -27,13 +27,13 @@
     height: auto;
     max-height: 360px;
     padding: 0;
-    .scrollbar(@x: hidden, @y: overlay);
+    .scrollbar(@x: hidden, @y: initial);
   }
   & .@{selection-prefix-cls} {
     height: auto;
     max-height: 360px;
     padding: 0;
-    .scrollbar(@x: hidden, @y: overlay);
+    .scrollbar(@x: hidden, @y: initial);
     & .@{list-prefix-cls} {
       height: auto;
       max-height: none;
@@ -51,7 +51,7 @@
       height: auto;
       max-height: 360px;
       padding-top: 8px;
-      .scrollbar(@x: hidden, @y: overlay);
+      .scrollbar(@x: hidden, @y: initial);
       & .@{list-prefix-cls} {
         max-height: none;
         padding: 0;

--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -35,6 +35,7 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
     suffix,
     onChange: controlledOnChange,
     renderItem,
+    onClick,
   } = props;
 
   const prefixCls = usePrefixCls(PREFIX);
@@ -83,6 +84,7 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
   const childrens = renderOptions.slice(0, collapse);
   const isNeedCollapse = useMemo(() => renderOptions?.length > collapse, [renderOptions, collapse]);
   const handleClick = (val: string) => {
+    onClick?.(val);
     // multiple
     if (isArray(value)) {
       const resultValue = indexOf(value, val) !== -1 ? difference(value, [val]) : [...value, val];
@@ -100,6 +102,7 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
 
   const renderChildren = (option: OptionProps) => {
     const renderedItem = renderItem?.(option);
+    const { onClick: optionOnClick } = option;
     return (
       <Item
         {...option}
@@ -111,7 +114,10 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
         isCascader={isCascader(mergedModel)}
         selectValue={value}
         selected={selectStatus(option?.value, value)}
-        onClick={handleClick}
+        onClick={(v) => {
+          optionOnClick?.(v);
+          handleClick(v);
+        }}
       >
         {renderedItem}
       </Item>
@@ -127,7 +133,13 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
     return (child as React.ReactNode[])?.map(
       (node: React.ReactElement<ItemProps & { isMultiple: boolean; isCascader: boolean }>) => {
         const {
-          props: { disabled: itemDisabled = undefined, prefix: itemPrefix, suffix: itemSuffix, onClick, ...rest },
+          props: {
+            disabled: itemDisabled = undefined,
+            prefix: itemPrefix,
+            suffix: itemSuffix,
+            onClick: nodeOnClick,
+            ...rest
+          },
         } = node;
 
         const item = { label: node?.props?.label, value: node?.props?.value } as OptionProps;
@@ -143,7 +155,7 @@ export const List = WithRef<HTMLDivElement, ListProps>((props, ref?) => {
           selected: selectStatus(item.value, value),
           onClick: (val: string) => {
             handleClick(val);
-            onClick?.(val);
+            nodeOnClick?.(val);
           },
         });
       }

--- a/src/list/demos/List.stories.tsx
+++ b/src/list/demos/List.stories.tsx
@@ -85,6 +85,7 @@ const Template: Story<ListProps> = (props) => {
   const wrapper = (e: React.ReactNode) => (
     <Popover
       placement="rightTop"
+      triggerStyle={{ display: 'inline' }}
       content={
         <div style={{ width: '200px', height: '200px', background: 'white', border: '1px solid black' }}>
           <h3>preview</h3>
@@ -337,13 +338,13 @@ const SelectionTemplate = () => {
       <div className="demo-box">
         <Selection>
           <List title="普通列表" onChange={(value) => console.log('value', value)}>
-            <Item lable="选中的List" prefix={renderEventIcon}>
+            <Item label="选中的List" prefix={renderEventIcon} value="123">
               选中的List
             </Item>
-            <Item lable="Regular Item" prefix={renderEventIcon}>
+            <Item label="Regular Item" prefix={renderEventIcon} value="234">
               Regular Item
             </Item>
-            <Item lable="Disabled Item" prefix={renderEventIcon} disabled>
+            <Item label="Disabled Item" prefix={renderEventIcon} value="456" disabled>
               Disabled Item
             </Item>
           </List>
@@ -392,20 +393,24 @@ const CollapseTemplate: Story<ItemProps> = () => {
     <>
       <h3>options</h3>
       <div className="demo-box">
-        <List options={collapseOptions} onChange={(value) => console.log('value', value)} />
+        <List
+          options={collapseOptions}
+          onChange={(value) => console.log('value', value)}
+          onClick={(v) => console.log('v', v)}
+        />
       </div>
       <h3>{`<Item> JSX`}</h3>
       <div className="demo-box">
         <List onChange={(value) => console.log('value', value)}>
           {collapseOptions.map((option) => (
-            <Item label={option?.label} value={option?.value} />
+            <Item label={option?.label} value={option?.value} onClick={(v) => console.log('v', v)} />
           ))}
         </List>
       </div>
       <div className="demo-box">
         <List onChange={(value) => console.log('value', value)}>
           {collapseOptions.map((option) => (
-            <Item value={option?.value}>
+            <Item value={option?.value} onClick={(v) => console.log('v', v)}>
               <div style={{ background: 'black' }}>{option?.label}</div>
             </Item>
           ))}

--- a/src/list/interfance.ts
+++ b/src/list/interfance.ts
@@ -58,6 +58,10 @@ export interface ListProps {
   /**
    *
    */
+  onClick?: (value: string) => void;
+  /**
+   *
+   */
   onChange?: (value?: string | string[], options?: OptionProps | OptionProps[]) => void;
   /**
    * 仅支持options 形式。自定义 item render 自定义render时会劫持onClick方法提供给List来使用
@@ -82,7 +86,7 @@ export interface OptionProps {
   prefix?: string | React.ReactNode;
   suffix?: string | React.ReactNode;
   wrapper?: (element: React.ReactNode) => React.ReactElement;
-
+  onClick?: (v: string) => void;
   [key: string]: unknown;
 }
 

--- a/src/pagination/RowsSelector.tsx
+++ b/src/pagination/RowsSelector.tsx
@@ -39,12 +39,10 @@ const RowsSelector: React.FC<{
             onPageSizeChange?.(currentPageSize, previousPageSizeRef.current);
             previousPageSizeRef.current = currentPageSize;
           }}
-          triggerProps={{
-            allowClear: false,
-            style: {
-              width: 85,
-              textAlign: 'left',
-            },
+          allowClear={false}
+          style={{
+            width: 85,
+            textAlign: 'left',
           }}
         />
       )}

--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -27,7 +27,7 @@ const Popover = (props: PopoverProps) => {
     overlayStyle,
     children,
     strategy = 'absolute',
-    offset = [0, 4],
+    offset = allowArrow ? [0, -2] : [0, 4],
     triggerClassName,
     triggerStyle,
     getContainer,
@@ -48,7 +48,6 @@ const Popover = (props: PopoverProps) => {
         {
           [`${prefixCls}__content-display`]: visible,
           [`${prefixCls}__content-arrow-allowed`]: allowArrow,
-          [`${prefixCls}__content-arrow-rejected`]: !allowArrow,
         },
         overlayClassName
       ),
@@ -220,7 +219,6 @@ const Popover = (props: PopoverProps) => {
       {children}
     </div>
   );
-
   if (supportRef(children)) {
     const cloneProps = {
       ...divRoles,

--- a/src/popover/style/index.less
+++ b/src/popover/style/index.less
@@ -20,7 +20,9 @@
     &-arrow {
       &-allowed {
         &[data-popper-placement^='top'] {
+          margin-bottom: 10px;
           & > .@{popover-arrow-prefix-cls} {
+            bottom: -4px;
             background: @popover-background-color;
             &::before {
               border-right: 1px solid @popover-border-color;
@@ -30,7 +32,9 @@
         }
 
         &[data-popper-placement^='bottom'] {
+          margin-top: 10px;
           & > .@{popover-arrow-prefix-cls} {
+            top: -5px;
             background: @popover-background-color;
             &::before {
               border-top: 1px solid @popover-border-color;
@@ -40,7 +44,9 @@
         }
 
         &[data-popper-placement^='left'] {
+          margin-right: 10px;
           & > .@{popover-arrow-prefix-cls} {
+            right: -4px;
             background: @popover-background-color;
             &::before {
               border-top: 1px solid @popover-border-color;
@@ -50,7 +56,9 @@
         }
 
         &[data-popper-placement^='right'] {
+          margin-left: 10px;
           & > .@{popover-arrow-prefix-cls} {
+            left: -5px;
             background: @popover-background-color;
             &::before {
               border-bottom: 1px solid @popover-border-color;

--- a/src/select/Trigger.tsx
+++ b/src/select/Trigger.tsx
@@ -1,11 +1,12 @@
 import { isNil } from 'lodash';
 import React from 'react';
 import Input from '../input';
+import WithRef from '../utils/withRef';
 import { TriggerProps } from './interface';
 
-const Trigger: React.FC<TriggerProps> = (props) => {
+const Trigger: React.ForwardRefRenderFunction<HTMLInputElement, TriggerProps> = (props, ref) => {
   const { value, ...rest } = props;
-  return <Input.Button value={isNil(value) ? undefined : value.toString()} {...rest} />;
+  return <Input.Button ref={ref} value={isNil(value) ? undefined : value.toString()} {...rest} />;
 };
 
-export default Trigger;
+export default WithRef(Trigger);

--- a/src/select/demos/Select.stories.tsx
+++ b/src/select/demos/Select.stories.tsx
@@ -28,21 +28,23 @@ const demoTemplate: Story<SelectProps> = (props) => {
         <Select
           options={options}
           value="1"
-          triggerProps={{ placeholder: '请选择' }}
+          placeholder="请选择"
           size="normal"
           {...props}
           onVisibleChange={() => action('visibleChange')}
         />
       </div>
       <div className="demo-box">
-        <Select disabled options={options} triggerProps={{ placeholder: '请选择' }} size="normal" {...props} />
+        <Select disabled options={options} placeholder="请选择" size="normal" {...props} />
       </div>
       <h3>自定义list,trigger宽度</h3>
       <div className="demo-box">
         <Select
           options={options}
-          overlayStyle={{ width: 240 }}
-          triggerProps={{ placeholder: '请选择', style: { width: 240, textAlign: 'left' }, allowClear: false }}
+          contentStyle={{ width: 240 }}
+          placeholder="请选择"
+          allowClear={false}
+          // triggerProps={{ placeholder: '请选择', style: { width: 240, textAlign: 'left' }, allowClear: false }}
           size="small"
           {...props}
         />
@@ -51,12 +53,9 @@ const demoTemplate: Story<SelectProps> = (props) => {
       <div className="demo-box">
         <Select
           options={options}
-          overlayStyle={{ width: 240 }}
-          triggerProps={{
-            placeholder: '请选择',
-            style: { width: 240, textAlign: 'left' },
-            allowClear: false,
-          }}
+          contentStyle={{ width: 240 }}
+          placeholder="请选择"
+          allowClear={false}
           size="small"
           {...props}
         />
@@ -67,32 +66,20 @@ const demoTemplate: Story<SelectProps> = (props) => {
           options={options}
           prefix={() => <PlusOutlined size="14px" />}
           suffix={() => <FilterOutlined size="14px" />}
-          overlayStyle={{ width: 240 }}
-          triggerProps={{
-            placeholder: '请选择',
-            style: { width: 240, textAlign: 'left' },
-          }}
+          contentStyle={{ width: 240 }}
+          placeholder="请选择"
+          allowClear={false}
           size="small"
           {...props}
         />
       </div>
       <h3>JSX--prefix</h3>
       <div className="demo-box">
-        <Select
-          triggerProps={{
-            placeholder: '请选择',
-            style: { width: 240, textAlign: 'left' },
-          }}
-        >
+        <Select style={{ width: '240px' }} placeholder="请选择" allowClear={false}>
           <Option label="JSX1" value="JSX1" />
           <Option label="JSX2" value="JSX2" />
         </Select>
-        <Select
-          triggerProps={{
-            placeholder: '请选择',
-            style: { width: 240, textAlign: 'left' },
-          }}
-        >
+        <Select style={{ width: '240px' }} placeholder="请选择" allowClear={false}>
           <Option value="JSX1" prefix="123">
             JSX1
           </Option>
@@ -115,7 +102,8 @@ export const Default = () => {
     <Select
       options={options}
       value="1"
-      triggerProps={{ placeholder: '请选择' }}
+      contentStyle={{ width: '300px' }}
+      placeholder="请选择"
       size="normal"
       onVisibleChange={() => action('visibleChange')}
     />

--- a/src/select/interface.ts
+++ b/src/select/interface.ts
@@ -8,38 +8,57 @@ export interface SelectProps extends Omit<ListProps, 'isMultiple' | 'onChange' |
    * dataSource 数据源
    */
   options?: OptionProps[];
-  className?: string;
-  style?: React.CSSProperties;
   size?: 'small' | 'normal';
   defaultValue?: string;
   value?: string;
-  /**
-   * 触发器参数
-   * @default `{ style: { width: '100%' } }`
-   */
-  triggerProps?: Omit<TriggerProps, 'value' | 'size' | 'prefixCls' | 'onInputChange' | 'disabled'>;
   onChange?: (val?: string, options?: OptionProps) => void;
-  /**
-   * 卡片类名
-   */
   overlayClassName?: string;
-  /**
-   * 卡片样式
-   */
   overlayStyle?: React.CSSProperties;
-  /**
-   * contentClassName?:string;
-   */
+
   contentClassName?: string;
   contentStyle?: React.CSSProperties;
-  /**
-   * popover 位置
-   */
   placement?: Placement;
   getContainer?: (node: HTMLElement) => HTMLElement;
   visible?: boolean;
-  hidePrefix?: boolean;
   onVisibleChange?: (visible: boolean) => void;
+
+  /** ================ trigger 相关的属性 ============== */
+  /**
+   * trigger className
+   */
+  className?: string;
+  /**
+   * trigger style
+   */
+  style?: React.CSSProperties;
+  /**
+   * 自定义title
+   */
+  title?: string;
+  placeholder?: string;
+  /**
+   * 自定义前缀icon
+   */
+  triggerPrefix?: React.ReactNode;
+  /**
+   * 自定义后缀的icon
+   */
+  triggerSuffix?: React.ReactNode;
+  maxWidth?: number;
+  hidePrefix?: boolean;
+  /**
+   * 是否允许clear
+   */
+  allowClear?: boolean;
+  onClear?: (e?: React.MouseEvent<Element, MouseEvent>) => void;
+  /**
+   * custom trigger render
+   */
+  renderTrigger?: () => React.ReactElement;
+  /**
+   * content 跟随 trigger宽度
+   */
+  autoWidth?: boolean;
 }
 
 export interface TriggerProps extends Omit<InputButtonProps, 'value' | 'active'> {


### PR DESCRIPTION
1. listPicker
2. select
3. casacder

整理了以上这些 组件 有关 trigger的样式控制，让控制起来的难度更小一些
- 移除 triggerProps 参数 将 style, className, allowClear, prefix, suffix, hidePrefix,title,placeholder拿出，需要各位配合着改一下有关这里样式的问题。
- inputButton 统一包装一层div, 可在组件内部使用 style、className样式来覆盖
- 综合考虑 将 inputButton 的ref修正在 新包装的div上，用来解决popover根据ref定位时，偏移问题


各类trigger样式控制:
跟随父级宽度 style={{width:'100%'}} 
自动宽(不需要设定宽度)
自定义宽度 style={{width:'240px'}}

二：
1. select 新增 allowWith 自动设置 content宽度 与 原有select保持一致
2. 修复 tooltip allow 小三角指向问题
3. list新增 onClick 方法
4. Input 组件重新定义ref指向
