### PR TITLE
fix(list-picker): 优化list-picker、cascader性能

### DIFF
--- a/src/cascader/Cascader.tsx
+++ b/src/cascader/Cascader.tsx
@@ -79,7 +79,10 @@ export const Cascader: React.FC<CascaderProps> = ({
     if (typeof propsRenderTrigger === 'function') {
       const node = propsRenderTrigger?.();
       return React.cloneElement(node, {
-        onClick: triggerClick,
+        onClick: (e: MouseEvent) => {
+          node?.props?.onClick?.(e);
+          triggerClick();
+        },
       });
     }
     return (

--- a/src/cascader/demos/Cascader.stories.tsx
+++ b/src/cascader/demos/Cascader.stories.tsx
@@ -82,7 +82,7 @@ const demoTemplate: Story<CascaderProps> = (props) => (
       <Cascader
         onChange={(val: any, opt: any) => console.log('val', val, opt)}
         options={defaultOptions}
-        placeholder="请选择"
+        placeholder="haha"
         size="normal"
         {...props}
       />
@@ -159,6 +159,6 @@ export const Demo = demoTemplate.bind({
   },
 });
 export const Default: Story<CascaderProps> = (args) => (
-  <Cascader {...args} options={defaultOptions} placeholder="请选择" size="normal" />
+  <Cascader {...args} value="apple.cut.bad" options={defaultOptions} placeholder="请选择" size="normal" />
 );
 Default.args = {};

--- a/src/list-picker/Recent.tsx
+++ b/src/list-picker/Recent.tsx
@@ -1,5 +1,5 @@
 import { slice } from 'lodash';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { List, OptionProps } from '../list';
 import { ListContext } from '../list/context';
 
@@ -12,18 +12,34 @@ interface RecentProps {
 
 const Recent: React.FC<RecentProps> & { isRecent: boolean } = (props) => {
   const { max = 5, title = '最近使用' } = props;
+  const [mayBeArray, setMayBearray] = useState<Map<string, OptionProps> | undefined>(new Map());
   const context = useContext(ListContext);
+  const { options } = context;
   const localStorageValue = window?.localStorage?.getItem(ITEM_KEY) || '[]';
   const matchValue = JSON.parse(localStorageValue); // localStorage.getItem('__GIO_SELECTION_KEY')
-  const mayBeArray = Array.from((context?.options ?? new Map())?.values());
-  const options = slice(
-    mayBeArray?.filter((value?: OptionProps) => matchValue?.includes(value?.value)),
-    0,
-    max
+  useEffect(() => {
+    setTimeout(() => {
+      setMayBearray(options);
+    }, 0);
+  }, [options]);
+  const listOptions: OptionProps[] = useMemo(
+    () =>
+      slice(
+        matchValue?.reduce((prev: OptionProps[], curr: string) => {
+          if (mayBeArray?.has(curr)) {
+            return [...prev, mayBeArray?.get(curr)];
+          }
+          return [...prev];
+        }, []),
+        0,
+        max
+      ),
+
+    [matchValue, max, mayBeArray]
   );
   const handleOnChange = (value?: string | string[], opts?: OptionProps | OptionProps[]) =>
     context?.onChange?.(value, opts);
-  return <List title={title} id={ITEM_KEY} options={options} value="" onChange={handleOnChange} />;
+  return <List title={title} id={ITEM_KEY} options={listOptions} value="" onChange={handleOnChange} />;
 };
 Recent.isRecent = true;
 export default Recent;

--- a/src/list-picker/demos/List-picker.stories.tsx
+++ b/src/list-picker/demos/List-picker.stories.tsx
@@ -237,27 +237,24 @@ const Template: Story<ListPickerProps> = () => {
             <Tabs value={activeTab} defaultValue="tab1" onChange={(key: string) => setActiveTab(key)}>
               <Tab label="tab1" value="tab1">
                 <List.Selection>
-                  {(context) => {
-                    const isEqualValue = context.value.length === 2;
-                    return (
-                      <>
-                        <CheckboxItem
-                          selected={isEqualValue}
-                          onClick={() => {
-                            if (isEqualValue) {
-                              context.onChange([]);
-                            } else {
-                              context.onChange(Array.from(context.options.keys()));
-                            }
-                          }}
-                          label="全部"
-                          value="all"
-                        />
+                  {(context) => (
+                    <>
+                      <CheckboxItem
+                        selected={context?.value?.length === 2}
+                        onClick={() => {
+                          if (context?.value?.length === 2) {
+                            context?.onChange([]);
+                          } else {
+                            context?.onChange(Array.from(context?.options.keys()));
+                          }
+                        }}
+                        label="全部"
+                        value="all"
+                      />
 
-                        <List options={multipleOptions} id="id" title="有item" />
-                      </>
-                    );
-                  }}
+                      <List options={multipleOptions} id="id" title="有item" />
+                    </>
+                  )}
                 </List.Selection>
               </Tab>
               <Tab label="tab2" value="tab2">
@@ -366,7 +363,11 @@ const Template: Story<ListPickerProps> = () => {
             <List.Selection options={largeOptions} />
           </ListPicker>
         </div>
-        <div className="demo-box" />
+        <div className="demo-box">
+          <ListPicker value="1.2" model="cascader">
+            <List options={[{ label: '1', value: '1', childrens: [{ label: '2', value: '2' }] }]} />
+          </ListPicker>
+        </div>
       </div>
     </div>
   );

--- a/src/list-picker/style/index.less
+++ b/src/list-picker/style/index.less
@@ -3,6 +3,7 @@
 @list-picker-prefix-cls: ~'@{component-prefix}-list-picker';
 @selection-prefix-cls: ~'@{component-prefix}-list--selection';
 @tab-panel-cls: ~'@{component-prefix}-tabs-tabpanel';
+@cascader-prefix-cls: ~'@{component-prefix}-cascader';
 
 @list-prefix-cls: ~'@{component-prefix}-list';
 .@{list-picker-prefix-cls} {
@@ -28,6 +29,9 @@
     max-height: 360px;
     padding: 0;
     .scrollbar(@x: hidden, @y: initial);
+  }
+  & .@{cascader-prefix-cls}--list {
+    padding: 8px;
   }
   & .@{selection-prefix-cls} {
     height: auto;

--- a/src/list/DragItem.tsx
+++ b/src/list/DragItem.tsx
@@ -57,12 +57,18 @@ const DragItem: React.FC<DragItemProps> = (props) => {
   return (
     <div
       className={classNames(`${prefixCls}--item`, `${prefixCls}--item--drag`, {
-        [`${prefixCls}--item--drag--disabled`]: disabled,
+        [`${prefixCls}--item--disabled`]: disabled,
       })}
       ref={ref}
       data-handler-id={handlerId}
     >
-      <MoveOutlined className={`${prefixCls}--item--drag--icon`} color="#ADB2C2" size="14px" />
+      <MoveOutlined
+        className={classNames(`${prefixCls}--item--drag--icon`, {
+          [`${prefixCls}--item--drag--icon--disabled`]: disabled,
+        })}
+        color="#ADB2C2"
+        size="14px"
+      />
       <Item label={label} value={value} disabled={disabled} {...rest} />
     </div>
   );

--- a/src/list/Item.tsx
+++ b/src/list/Item.tsx
@@ -1,31 +1,21 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { ItemProps } from './interfance';
 import BaseItem from './inner/baseItem';
 import CheckboxItem from './inner/CheckboxItem';
 import CalcaderItem from './inner/CascaderItem';
 import WithRef from '../utils/withRef';
+import { ListContext } from './context';
 
-export const Item = WithRef<HTMLLIElement, ItemProps & { isMultiple?: boolean; isCascader?: boolean }>(
-  (props, ref?) => {
-    const { label, value, disabled, isMultiple = false, isCascader, selectValue, ...rest } = props;
-
-    if (isMultiple) {
-      return <CheckboxItem ref={ref} label={label} value={value} disabled={disabled} {...rest} />;
-    }
-    if (isCascader) {
-      return (
-        <CalcaderItem
-          ref={ref}
-          label={label as string}
-          value={value as string}
-          selectValue={selectValue as string}
-          disabled={disabled}
-          {...rest}
-        />
-      );
-    }
-    return <BaseItem ref={ref} label={label} value={value} disabled={disabled} {...rest} />;
+export const Item = WithRef<HTMLLIElement, ItemProps>((props, ref?) => {
+  const { label, value, disabled, ...rest } = props;
+  const { model } = useContext(ListContext);
+  if (model === 'multiple') {
+    return <CheckboxItem ref={ref} label={label} value={value} disabled={disabled} {...rest} />;
   }
-);
+  if (model === 'cascader') {
+    return <CalcaderItem ref={ref} label={label as string} value={value as string} disabled={disabled} {...rest} />;
+  }
+  return <BaseItem ref={ref} label={label} value={value} disabled={disabled} {...rest} />;
+});
 
 export default Item;

--- a/src/list/Selection.tsx
+++ b/src/list/Selection.tsx
@@ -22,12 +22,8 @@ const Selection: React.FC<SelectionProps> & { isSelection?: boolean } = (props) 
     [isSelection, options]
   );
   const cache = useCacheOptions();
-  const {
-    value: contextValue,
-    model: contextModel,
-    setOptions: contextSetOptions,
-    onChange: contextOnChange,
-  } = useContext(ListContext);
+  const contextVal = useContext(ListContext);
+  const { setOptions: contextSetOptions, onChange: contextOnChange } = contextVal;
   const setOptions = (opts?: OptionProps[]) => {
     cache?.setOptions(opts);
     contextSetOptions?.(opts);
@@ -61,10 +57,9 @@ const Selection: React.FC<SelectionProps> & { isSelection?: boolean } = (props) 
   const selectionProvider = (child: React.ReactNode) => (
     <ListContext.Provider
       value={{
-        value: contextValue,
+        ...contextVal,
         options: cache.options,
         onChange: contextOnChange,
-        model: contextModel,
         setOptions,
       }}
     >

--- a/src/list/context.tsx
+++ b/src/list/context.tsx
@@ -6,8 +6,13 @@ import { OptionProps, ListProps } from './interfance';
 export interface ListContextProps {
   value?: string | string[];
   model?: 'single' | 'cascader' | 'multiple';
+  disabled?: boolean;
+  selectParent?: any;
   onChange?: (value?: string | string[], options?: OptionProps | OptionProps[]) => void;
+  onClick?: (value?: string) => void;
   options?: Map<string, OptionProps>;
+  prefix?: (option?: OptionProps) => string | React.ReactNode;
+  suffix?: (option?: OptionProps) => string | React.ReactNode;
   setOptions?: (options?: OptionProps[]) => void;
   getOptionByValue?: (optValue?: string) => OptionProps | undefined;
   getOptionsByValue?: (optValue?: string | string[]) => OptionProps | OptionProps[] | undefined;
@@ -15,9 +20,14 @@ export interface ListContextProps {
 }
 const defaultList: ListContextProps = {
   value: '',
-  model: undefined,
+  model: 'single',
+  disabled: false,
+  selectParent: undefined,
   onChange: noop,
+  onClick: noop,
   setOptions: noop,
+  prefix: undefined,
+  suffix: undefined,
   getOptionByValue: undefined,
   getOptionsByValue: undefined,
   getLabelByValue: undefined,

--- a/src/list/demos/List.stories.tsx
+++ b/src/list/demos/List.stories.tsx
@@ -82,19 +82,6 @@ const CascaderDemo = (props: any) => {
 const Template: Story<ListProps> = (props) => {
   const [value, setValue] = useState([]);
   const [cascaderValue, setCascadervalue] = useState('1.1-1');
-  const wrapper = (e: React.ReactNode) => (
-    <Popover
-      placement="rightTop"
-      triggerStyle={{ display: 'inline' }}
-      content={
-        <div style={{ width: '200px', height: '200px', background: 'white', border: '1px solid black' }}>
-          <h3>preview</h3>
-        </div>
-      }
-    >
-      {e}
-    </Popover>
-  );
   return (
     <>
       cascaderitem
@@ -140,7 +127,23 @@ const Template: Story<ListProps> = (props) => {
           </Item>
         </List> */}
         <h3>option render preview</h3>
-        <List options={[{ label: '1', value: '1', wrapper }]} />
+        <List
+          onClick={(v) => console.log('list触发 onClick', v)}
+          onChange={(v, o) => console.log('list触发 onChange', v, o)}
+        >
+          <Popover
+            placement="rightTop"
+            content={
+              <div style={{ width: '200px', height: '200px', background: 'white', border: '1px solid black' }}>
+                <h3>preview</h3>
+              </div>
+            }
+          >
+            <span>
+              <Item value="1" label="1" onClick={(v) => console.log('item click', v)} />
+            </span>
+          </Popover>
+        </List>
       </div>
       <div className="demo-box">
         <List {...props}>

--- a/src/list/inner/CheckboxItem.tsx
+++ b/src/list/inner/CheckboxItem.tsx
@@ -1,27 +1,37 @@
-import React, { DOMAttributes } from 'react';
+import React, { DOMAttributes, useContext, useMemo } from 'react';
 import Checkbox from '../../checkbox/Checkbox';
 import { PREFIX } from '../constants';
 import usePrefixCls from '../../utils/hooks/use-prefix-cls';
 import { BaseItemProps } from '../interfance';
 import Item from './baseItem';
 import WithRef from '../../utils/withRef';
+import { ListContext } from '../context';
+import { selectStatus } from '../util';
 
 const CheckboxItem: React.ForwardRefRenderFunction<
   HTMLLIElement,
   BaseItemProps & Omit<DOMAttributes<HTMLInputElement | HTMLLIElement>, 'onClick'>
 > = (props, ref?) => {
-  const { selected, value, children, onClick, disabled, ...rest } = props;
+  const { value, children, onClick, disabled, selected, ...rest } = props;
   const prefixCls = `${usePrefixCls(PREFIX)}--item`;
+
+  /** context */
+  const context = useContext(ListContext);
+  const { value: contextValue, disabled: contextDisabled, onClick: contextOnClick } = context;
+  const mergedDisabled = disabled ?? contextDisabled;
+
+  const mergeSelected = useMemo(() => selected ?? selectStatus(value, contextValue), [selected, contextValue, value]);
 
   const contentRender = (element: React.ReactNode) => (
     <>
       <Checkbox
-        checked={selected}
+        checked={mergeSelected}
         className={`${prefixCls}--checkbox`}
         value={value}
-        disabled={disabled}
+        disabled={mergedDisabled}
         onClick={(e) => {
-          if (!disabled) {
+          if (!mergedDisabled) {
+            contextOnClick?.(value);
             onClick?.(value);
             e?.stopPropagation();
           }
@@ -31,7 +41,7 @@ const CheckboxItem: React.ForwardRefRenderFunction<
     </>
   );
   return (
-    <Item ref={ref} disabled={disabled} onClick={onClick} value={value} contentRender={contentRender} {...rest}>
+    <Item ref={ref} disabled={mergedDisabled} onClick={onClick} value={value} contentRender={contentRender} {...rest}>
       {children}
     </Item>
   );

--- a/src/list/interfance.ts
+++ b/src/list/interfance.ts
@@ -58,7 +58,7 @@ export interface ListProps {
   /**
    *
    */
-  onClick?: (value: string) => void;
+  onClick?: (value?: string) => void;
   /**
    *
    */
@@ -85,8 +85,11 @@ export interface OptionProps {
   disabledTooltip?: string;
   prefix?: string | React.ReactNode;
   suffix?: string | React.ReactNode;
+  /**
+   * @deprecated 未来版本迭代后会弃用 1.x.x -> 2.x.x
+   */
   wrapper?: (element: React.ReactNode) => React.ReactElement;
-  onClick?: (v: string) => void;
+  onClick?: (v?: string) => void;
   [key: string]: unknown;
 }
 
@@ -98,9 +101,6 @@ export interface DragItemProps extends ItemProps {
 export interface CascaderItemProps extends BaseItemProps {
   label: string;
   value: string;
-  selectValue?: string;
-  selectParent?: OptionProps[];
-  onChange?: (value: string, option?: CascaderItemProps) => void;
   childrens?: CascaderItemProps[];
 }
 export interface ItemProps
@@ -131,7 +131,7 @@ export interface BaseItemProps extends Pick<OptionProps, 'value' | 'disabled' | 
   children?: React.ReactNode;
   disabledTooltip?: string;
   selected?: boolean;
-  onClick?: (value: string) => void;
+  onClick?: (value?: string) => void;
 }
 
 export interface TriggerProps {

--- a/src/list/style/index.less
+++ b/src/list/style/index.less
@@ -100,6 +100,24 @@
     vertical-align: middle;
     border-radius: 4px;
     cursor: pointer;
+    &--drag {
+      justify-content: flex-start;
+      cursor: all-scroll;
+      & > .@{list-prefix-cls}--item {
+        margin-bottom: 0;
+        padding: 0;
+        background-color: inherit;
+      }
+      &--icon {
+        margin-right: 8px;
+        &--disabled {
+          cursor: not-allowed;
+        }
+      }
+      &--disabled {
+        cursor: no-drop;
+      }
+    }
     &--ellipsis {
       display: inline-block;
       overflow: hidden;
@@ -148,21 +166,7 @@
     &--interval {
       margin-top: 4px;
     }
-    &--drag {
-      justify-content: flex-start;
-      cursor: all-scroll;
-      & > .@{list-prefix-cls}--item {
-        margin-bottom: 0;
-        padding: 0;
-        background-color: inherit;
-      }
-      &--icon {
-        margin-right: 8px;
-      }
-      &--disabled {
-        cursor: no-drop;
-      }
-    }
+
     &--text {
       flex-grow: 1;
     }

--- a/src/list/util.ts
+++ b/src/list/util.ts
@@ -1,4 +1,4 @@
-import { isArray, isEmpty, isUndefined } from 'lodash';
+import { concat, difference, indexOf, isArray, isEmpty, isNil, isUndefined } from 'lodash';
 import toArray from 'rc-util/lib/Children/toArray';
 import React from 'react';
 import { ListProps } from '.';
@@ -8,7 +8,22 @@ type OtherProps = ListProps;
 
 export const isMultipe = (model: ModelType) => model === 'multiple';
 export const isCascader = (model: ModelType) => model === 'cascader';
-
+export const getResultValue = (value?: string[], val?: string) => {
+  if (indexOf(value, val) !== -1) {
+    return difference(value, [val]);
+  }
+  if (typeof val === 'string') {
+    return concat(value, val);
+  }
+  return value;
+  //  ?  :
+};
+export const selectStatus = (value?: string, values?: string | string[]) => {
+  if (!isNil(value)) {
+    return isArray(values) ? (values as string[])?.indexOf(value) !== -1 : values === value;
+  }
+  return undefined;
+};
 const deepChildren = (children?: OptionProps[]): any[] => {
   if (children) {
     return [...children, ...deepChildren(children?.[0]?.childrens as OptionProps[])];

--- a/src/select/Select.tsx
+++ b/src/select/Select.tsx
@@ -83,7 +83,10 @@ const Select: React.FC<SelectProps> & { isSelect?: boolean } = (props) => {
     if (typeof propsRenderTrigger === 'function') {
       const node = propsRenderTrigger?.();
       return React.cloneElement(node, {
-        onClick: triggerClick,
+        onClick: (e: MouseEvent) => {
+          node?.props?.onClick?.(e);
+          triggerClick();
+        },
       });
     }
     return (


### PR DESCRIPTION
本次更新将 Item的wrapper设为 废弃，在未来可能会完全丢弃掉该方法：
目前新增了如下替代wrapper的方式：

```jsx
<Popover content={()=> {
/** some code ...... */
}}>
<List.Item value='free'>支持</List.Item>
</Popover>

```
当然，本次升级后，理论上可以用ListContext 来模拟 Item 的行为，您完全可以自主的创建一个全新的Item 并且还可以接入到 List、Cascader、list-picker 、 select 等等当中