### PR TITLE
fix(footer):fix default footer

### DIFF
--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -22,6 +22,7 @@ const Modal: React.FC<ModalProps> = ({
   onClose,
   closeIcon,
   maskClosable = false,
+  footer,
   ...restProps
 }: ModalProps) => {
   const prefix = usePrefixCls('modal', customPrefixCls);
@@ -43,7 +44,7 @@ const Modal: React.FC<ModalProps> = ({
 
     return (
       <div className={cls}>
-        {restProps.footer || (
+        {footer || (
           <div>
             <Button
               type="secondary"


### PR DESCRIPTION
将footer参数从restProps中拿出来，避免最后结构restProps时覆盖自定义footer