### PR TITLE
fix(panel): the title should be vertically centered with the icon when there is no description

### DIFF
--- a/src/panel/style/index.less
+++ b/src/panel/style/index.less
@@ -30,7 +30,11 @@
 
     &__meta {
       position: relative;
+      display: flex;
       flex: 1 1 100%;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
       &__title {
         .text-h2();
         color: @gray-5;


### PR DESCRIPTION
![panel1](https://user-images.githubusercontent.com/48519459/145567907-322c5c8a-c046-41ba-8feb-65e5498e7368.png)
![panel2](https://user-images.githubusercontent.com/48519459/145567910-ed9034d0-936f-441a-b8cb-4e8822f91311.png)

