### PR TITLE
fix(popover): fix react wraning

### DIFF
--- a/src/popover/Popover.tsx
+++ b/src/popover/Popover.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useRef, useLayoutEffect, useEffect } from 'react';
 import classNames from 'classnames';
-import { debounce, isFunction, isNil } from 'lodash';
+import { debounce, isFunction, isNil, omit } from 'lodash';
 import ReactDOM from 'react-dom';
 import ResizeObserver from 'rc-resize-observer';
 import { usePrefixCls } from '@gio-design/utils';
@@ -219,7 +219,7 @@ const Popover = (props: PopoverProps) => {
       onMouseLeave={onContentMouseLeave}
       onClick={onContentClick}
       role="none"
-      {...rest}
+      {...omit(rest, 'arrowPointAtCenter')}
     >
       {allowArrow && <div className={`${prefixCls}__arrow`} ref={arrowElement} style={{ ...styles.arrow }} />}
       <div className={contentInnerCls} style={overlayInnerStyle}>

--- a/src/popover/interface.ts
+++ b/src/popover/interface.ts
@@ -38,6 +38,7 @@ export interface PopoverProps {
   /**
    * 箭头是否指向目标元素中心
    * @default false
+   * @deprecated
    */
   arrowPointAtCenter?: boolean;
   /**


### PR DESCRIPTION
Warning: React does not recognize the `arrowPointAtCenter` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `arrowpointatcenter` instead. If you accidentally passed it from a parent component, remove it from the DOM element.