### PR TITLE
fix(static-date-picker): fix some bug

### DIFF
--- a/src/static-date-picker/interfaces.ts
+++ b/src/static-date-picker/interfaces.ts
@@ -1,4 +1,4 @@
-import { PanelMode, Locale } from 'rc-picker/lib/interface';
+import { Locale, PickerMode } from 'rc-picker/lib/interface';
 import { CommonProps } from '@gio-design/utils';
 
 export type DatePickerLocale = Omit<Locale, 'locale'>;
@@ -23,9 +23,9 @@ export interface StaticDatePickerProps extends CommonProps {
    * 日历面板切换的回调
    *
    * @param value - 当前日期 `Date`
-   * @param mode - 当前模式，目前只会是 `date` 模式
+   * @param mode - 当前模式
    */
-  onPanelChange?: (value: Date, mode: PanelMode) => void;
+  onPanelChange?: (value: Date, mode: PickerMode) => void;
   /**
    * 日期发生变化时的回调
    *

--- a/src/static-date-picker/style/index.less
+++ b/src/static-date-picker/style/index.less
@@ -123,6 +123,11 @@
       cursor: pointer;
     }
 
+    &-start,
+    &-end {
+      color: @gray-3;
+    }
+
     &::before {
       position: absolute;
       right: 0;
@@ -179,7 +184,7 @@
       background: @blue-3;
     }
 
-    &-in-view&-disabled {
+    &-disabled {
       color: @gray-3;
       cursor: not-allowed;
 

--- a/src/static-past-time-picker/RelativeRangeBody.tsx
+++ b/src/static-past-time-picker/RelativeRangeBody.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { startOfDay, startOfToday, startOfYesterday, subMonths } from 'date-fns';
+import { startOfDay, startOfYesterday } from 'date-fns';
 import DatePicker from '../static-date-picker';
 import DateRangePicker from '../static-date-range-picker';
 import { RelativeRangeBodyProps } from './interfaces';
@@ -11,14 +11,7 @@ function RelativeRangeBody({ dateRange, fixedMode, onRangeChange, disabledDate }
     };
     return <DatePicker disabledDate={disabledDate} value={dateRange[0]} onSelect={handleOnSelect} />;
   }
-  return (
-    <DateRangePicker
-      defaultViewDates={[subMonths(startOfToday(), 1), startOfYesterday()]}
-      disabledDate={disabledDate}
-      onSelect={onRangeChange}
-      value={dateRange as [Date, Date]}
-    />
-  );
+  return <DateRangePicker disabledDate={disabledDate} onSelect={onRangeChange} value={dateRange as [Date, Date]} />;
 }
 
 export default RelativeRangeBody;


### PR DESCRIPTION
1. 解决了 #1863 引入的 `disabledDate` 判断错误，导致将月份和年份也错误 disabled 的问题；
2. 解决了过去动态时段-回显数据时，时间选择器面板未定位到已选定日期的问题；