### PR TITLE
fix(filter-picker): fix style of FilterCondition

### DIFF
--- a/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/attrSelect.less
+++ b/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/attrSelect.less
@@ -28,3 +28,30 @@
     padding: 0;
   }
 }
+
+.filter-condition_select {
+  position: relative;
+  display: inline-block;
+  box-sizing: border-box;
+  width: auto;
+  min-width: 40px;
+  max-width: 160px;
+  height: 30px;
+  margin-left: 8px;
+  padding: 4px 8px;
+  color: #313e75;
+  font-size: 14px;
+  line-height: 22px;
+  text-align: left;
+  vertical-align: middle;
+  border-radius: 4px;
+
+  .filter-condition_select-text {
+    display: inline-block;
+    width: 100%;
+    padding-right: 20px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}

--- a/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/index.tsx
+++ b/src/legacy/filter-picker/components/FilterList/Expression/FilterCondition/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useLocale } from '@gio-design/utils';
 import parseValuesToText from './utils';
 import FilterAttrOverlay from './FilterAttrOverlay';
@@ -54,11 +54,6 @@ function FilterCondition(props: FilterConditionProps) {
     setVisible(v);
   };
 
-  useEffect(() => {
-    console.log('mount');
-    return () => console.log('unmount');
-  }, []);
-
   const curryDimensionValueRequest = (
     (timeRangeValue: string, measurementsValue: any[]) => (dimension: string, keyword: string) =>
       dimensionValueRequest?.({
@@ -85,6 +80,8 @@ function FilterCondition(props: FilterConditionProps) {
         disabled={conditionText === textObject.selectFilter}
         getContainer={() => document.body}
         placement="topLeft"
+        distoryOnHide={false}
+        trigger="click"
       >
         <span className="filter-condition_select-text">{conditionText}</span>
       </Tooltip>

--- a/src/legacy/filter-picker/components/FilterList/Expression/index.less
+++ b/src/legacy/filter-picker/components/FilterList/Expression/index.less
@@ -23,31 +23,4 @@
     background-color: #dfe4ee;
     border-radius: 12px;
   }
-
-  .filter-condition_select {
-    position: relative;
-    display: inline-block;
-    box-sizing: border-box;
-    width: auto;
-    min-width: 40px;
-    max-width: 160px;
-    height: 30px;
-    margin-left: 8px;
-    padding: 4px 8px;
-    color: #313e75;
-    font-size: 14px;
-    line-height: 22px;
-    text-align: left;
-    vertical-align: middle;
-    border-radius: 4px;
-
-    .filter-condition_select-text {
-      display: inline-block;
-      width: 100%;
-      padding-right: 20px;
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-  }
 }


### PR DESCRIPTION
`filter-condition` 的样式包在了 `.expression-box` 选择器中，如果单独使用 `filter-condition` 组件，会导致样式失效，所以需要单独拎出来。